### PR TITLE
Closes #87 - lowering ubuntu image to 22.04

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
 
   compile_and_test:
     name: Test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
         run: rm -rf ~/.m2/repository/io/kadai
 
   release_artifacts:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     name: Release artifacts to Sonatype-Central
     if: github.repository == 'kadai-io/KadaiAdapter' && ( startsWith(github.ref, 'refs/tags') || github.ref == 'refs/heads/master' ) && github.head_ref == ''
     needs: [ compile_and_test ]
@@ -119,7 +119,7 @@ jobs:
         uses: andymckay/cancel-action@0.5
 
   upload_to_sonar:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     name: Upload SonarQube analysis to sonarcloud
     # no pull request and not on release
     if: github.head_ref == '' && !startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
Ubuntu 24 seems to introduce heavy flakiness with at least one test, see [CI](https://github.com/kadai-io/KadaiAdapter/actions/runs/13669219947/job/38239040809?pr=83#step:5:7824).
Just lower the images version for now.

<!-- if needed please write above the given line -->

### Thanks for your PR! Please fill out the following list :)

---

- [x] I put the ticket or multiple tickets in review
- [x] Commit message format → Closes #&lt;Issue Number&gt; - Your commit message.
- [ ] Sonarcloud link : \<add the link here>
- [x] No documentation update needed
- [ ] Link to PR with documentation update: \<add the link here>
- [x] No Release Notes needed
- [ ] Release Notes :

<!-- Please write your release notes between ```-->

```

```