### PR TITLE
Closes #124: Make URL for Health Check configurable

### DIFF
--- a/kadai-adapter-camunda-spring-boot-example/src/main/resources/application.properties
+++ b/kadai-adapter-camunda-spring-boot-example/src/main/resources/application.properties
@@ -60,7 +60,17 @@ management.endpoints.web.exposure.include= *
 management.endpoint.health.show-details=always
 #management.health.external-services.enabled=false
 #management.health.external-services.camunda.enabled=false
-camundaOutboxService.port=8081
-camundaOutboxService.address=http://localhost
-outbox.context-path=example-context-root
+#
+# Configure Health Check URLs
+camunda-service.address=http://localhost
+camunda-service.port=8081
+camunda-service.context-path=example-context-root
+camunda-service.endpoint=engine-rest/engine
+
+outbox-service.address=http://localhost
+outbox-service.port=8081
+outbox-service.context-path=example-context-root
+outbox-service.endpoint=outbox-rest/events/count
+outbox-service.query=retries=0
+#
 #kadai.adapter.xsrf.token=KAD_UNIQUE_TOKEN_123

--- a/kadai-adapter-camunda-spring-boot-test/src/main/resources/application.properties
+++ b/kadai-adapter-camunda-spring-boot-test/src/main/resources/application.properties
@@ -98,6 +98,4 @@ management.endpoints.web.exposure.include= *
 management.endpoint.health.show-details= always
 management.health.external-services.include=external-services
 management.health.external-services.enabled=true
-camundaOutboxService.port=10020
-camundaOutboxService.address=http://localhost
 #kadai.adapter.xsrf.token=KAD_UNIQUE_TOKEN_123

--- a/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/CamundaHealthCheckTest.java
+++ b/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/CamundaHealthCheckTest.java
@@ -29,7 +29,7 @@ class CamundaHealthCheckTest {
     this.restTemplate = Mockito.mock(RestTemplate.class);
     this.camundaHealthCheckSpy =
         Mockito.spy(
-            new CamundaHealthCheck(restTemplate, "http://localhost", 8090, "example-context-root"));
+            new CamundaHealthCheck(restTemplate, "http://localhost", 8090, "example-context-root", "engine-rest/engine", null));
   }
 
   @Test

--- a/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/OutboxHealthCheckTest.java
+++ b/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/OutboxHealthCheckTest.java
@@ -29,7 +29,7 @@ class OutboxHealthCheckTest {
     this.restTemplate = Mockito.mock(RestTemplate.class);
     this.outboxHealthCheckSpy =
         Mockito.spy(
-            new OutboxHealthCheck(restTemplate, "http://localhost", 8090, "example-context-root"));
+            new OutboxHealthCheck(restTemplate, "http://localhost", 8090, "example-context-root", "outbox-rest/events/count", "retries=0"));
   }
 
   @Test

--- a/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/CamundaHealthCheck.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/CamundaHealthCheck.java
@@ -11,21 +11,27 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class CamundaHealthCheck implements HealthIndicator {
 
   private final RestTemplate restTemplate;
-  private final String camundaOutboxAddress;
-  private final int camundaOutboxPort;
+  private final String camundaAddress;
+  private final Integer camundaPort;
   private final String contextPath;
+  private final String camundaEndpointPath;
+  private final String camundaQuery;
 
   private URI url;
 
   public CamundaHealthCheck(
       RestTemplate restTemplate,
-      String camundaOutboxAddress,
-      int camundaOutboxPort,
-      String contextPath) {
+      String camundaAddress,
+      Integer camundaPort,
+      String contextPath,
+      String camundaEndpointPath,
+      String camundaQuery) {
     this.restTemplate = restTemplate;
-    this.camundaOutboxAddress = camundaOutboxAddress;
-    this.camundaOutboxPort = camundaOutboxPort;
+    this.camundaAddress = camundaAddress;
+    this.camundaPort = camundaPort;
     this.contextPath = contextPath;
+    this.camundaEndpointPath = camundaEndpointPath;
+    this.camundaQuery = camundaQuery;
     init();
   }
 
@@ -45,14 +51,25 @@ public class CamundaHealthCheck implements HealthIndicator {
   }
 
   private void init() {
-    this.url =
-        UriComponentsBuilder.fromUriString(camundaOutboxAddress)
-            .port(camundaOutboxPort)
-            .pathSegment(contextPath)
-            .pathSegment("engine-rest")
-            .pathSegment("engine")
-            .build()
-            .toUri();
+    UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(camundaAddress);
+
+    if (camundaPort != null) {
+      if (camundaPort <= 0) {
+        throw new IllegalArgumentException(
+            "Port must be a positive integer. Provided: " + camundaPort);
+      }
+      builder.port(camundaPort);
+    }
+
+    if (contextPath != null) {
+      builder.pathSegment(contextPath).pathSegment(camundaEndpointPath);
+    }
+
+    if (camundaQuery != null) {
+      builder.query(camundaQuery);
+    }
+
+    this.url = builder.build().toUri();
   }
 
   private ResponseEntity<CamundaEngineInfoRepresentationModel[]> pingCamundaRest() {

--- a/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/CamundaSystemConfigurationProperties.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/CamundaSystemConfigurationProperties.java
@@ -1,0 +1,54 @@
+package io.kadai.adapter.monitoring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "camunda-service")
+public class CamundaSystemConfigurationProperties {
+  private String address = "http://localhost";
+  private Integer port = null;
+  private String contextPath = null;
+  private String endpoint = "engine-rest/engine";
+  private String query = null;
+
+  public String getAddress() {
+    return address;
+  }
+
+  public void setAddress(String address) {
+    this.address = address;
+  }
+
+  public Integer getPort() {
+    return port;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  public String getContextPath() {
+    return contextPath;
+  }
+
+  public void setContextPath(String contextPath) {
+    this.contextPath = contextPath;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public void setQuery(String query) {
+    this.query = query;
+  }
+}

--- a/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/OutboxSystemConfigurationProperties.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/OutboxSystemConfigurationProperties.java
@@ -1,0 +1,54 @@
+package io.kadai.adapter.monitoring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "outbox-service")
+public class OutboxSystemConfigurationProperties {
+  private String address = "http://localhost";
+  private Integer port = null;
+  private String contextPath = null;
+  private String endpoint = "outbox-rest/events/count";
+  private String query = null;
+
+  public String getAddress() {
+    return address;
+  }
+
+  public void setAddress(String address) {
+    this.address = address;
+  }
+
+  public Integer getPort() {
+    return port;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  public String getContextPath() {
+    return contextPath;
+  }
+
+  public void setContextPath(String contextPath) {
+    this.contextPath = contextPath;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public void setQuery(String query) {
+    this.query = query;
+  }
+}


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it: https://github.com/kadai-io/kadai-doc/pull/100
- [x] If extra release-notes are required, they're listed indented below:
  - External service health checks URLs for Camunda and Outbox are now independently configurable through application properties. This enables flexible and environment-specific setup of base address, port, context path, endpoint path, and query parameters.

  - Camunda Service Properties:
    - camundaService.address (default: http://localhost)
    - camundaService.port (optional)
    - camundaService.context-path (default: empty)
    - camundaService.endpoint (default: engine-rest/engine)
    - camundaService.query (optional)

  - Outbox Service Properties:
    - outboxService.address (default: http://localhost)
    - outboxService.port (optional)
    - outboxService.context-path (default: empty)
    - outboxService.endpoint (default: outbox-rest/events/count)
    - outboxService.query (optional)