### PR TITLE
Closes #146: Make both Kadai And Taskana Attributes from Process Model Readable

### DIFF
--- a/kadai-adapter-camunda-spring-boot-test/src/main/resources/processes/simple_user_task_process_with_both_prefixes.bpmn
+++ b/kadai-adapter-camunda-spring-boot-test/src/main/resources/processes/simple_user_task_process_with_both_prefixes.bpmn
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_both_prefixes" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <bpmn:process id="simple_user_task_process_with_both_prefixes" isExecutable="true">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="kadai.domain" value="DOMAIN_A" />
+        <camunda:property name="taskana.domain" value="DOMAIN_A" />
+        <camunda:property name="kadai-attributes" value="amount,item" />
+        <camunda:property name="taskana-attributes" value="amount,item" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="UserTask_1" name="UserTask1">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="kadai.classification-key" value="L1050" />
+          <camunda:property name="taskana.classification-key" value="L9999" />
+        </camunda:properties>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="amount">42</camunda:inputParameter>
+          <camunda:inputParameter name="item">TestItem</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="UserTask_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="UserTask_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="simple_user_task_process_with_both_prefixes">
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="200" y="100" />
+        <di:waypoint x="300" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="400" y="100" />
+        <di:waypoint x="500" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="164" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_1_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="300" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="500" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions> 

--- a/kadai-adapter-camunda-spring-boot-test/src/main/resources/processes/simple_user_task_process_with_taskana_prefix.bpmn
+++ b/kadai-adapter-camunda-spring-boot-test/src/main/resources/processes/simple_user_task_process_with_taskana_prefix.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_taskana_prefix" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <bpmn:process id="simple_user_task_process_with_taskana_prefix" isExecutable="true">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="taskana.domain" value="DOMAIN_A" />
+        <camunda:property name="taskana-attributes" value="amount,item" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="UserTask_1" name="UserTask1">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="taskana.classification-key" value="L1050" />
+        </camunda:properties>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="amount">42</camunda:inputParameter>
+          <camunda:inputParameter name="item">TestItem</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="UserTask_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="UserTask_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="simple_user_task_process_with_taskana_prefix">
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="200" y="100" />
+        <di:waypoint x="300" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="400" y="100" />
+        <di:waypoint x="500" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="164" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_1_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="300" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="500" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions> 

--- a/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/TestTaskAcquisition.java
+++ b/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/TestTaskAcquisition.java
@@ -51,6 +51,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.ThrowingConsumer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,8 +75,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TestTaskAcquisition.class);
   @Autowired AdapterManager adapterManager;
-  @Autowired
-  private LastSchedulerRun lastSchedulerRun;
+  @Autowired private LastSchedulerRun lastSchedulerRun;
 
   @Value("${kadai-system-connector-camundaSystemURLs}")
   private String configuredSystemConnectorUrls;
@@ -166,9 +167,8 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void
-      should_CreateKadaiTask_When_StartUserTaskProcessInstanceWithEmptyExtensionPropertyInCamunda()
-          throws Exception {
+  void should_CreateKadaiTask_When_StartUserTaskProcessInstanceWithEmptyExtensionPropertyInCamunda()
+      throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -298,8 +298,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       throws Exception {
 
     String variables =
-        "\"variables\": {\"kadai.manual-priority\": {\"value\":\"555\", "
-            + "\"type\":\"string\"}}";
+        "\"variables\": {\"kadai.manual-priority\": {\"value\":\"555\", " + "\"type\":\"string\"}}";
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
             "simple_user_task_process", variables);
@@ -318,9 +317,8 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void
-      should_CreateKadaiTaskWithDefaultManualPriority_When_StartCamundaTaskWithoutManualPriority()
-          throws Exception {
+  void should_CreateKadaiTaskWithDefaultManualPriority_When_StartCamundaTaskWithoutManualPriority()
+      throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -610,9 +608,8 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void
-      should_CreateKadaiTasksWithCorrectDomains_When_StartProcessWithDomainsInExtensionProperties()
-          throws Exception {
+  void should_CreateKadaiTasksWithCorrectDomains_When_StartProcessWithDomainsInExtensionProperties()
+      throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -831,6 +828,50 @@ class TestTaskAcquisition extends AbsIntegrationTest {
         };
 
     return DynamicTest.stream(input, Pair::getLeft, test);
+  }
+
+  @WithAccessId(
+      user = "teamlead_1",
+      groups = {"taskadmin"})
+  @ParameterizedTest
+  @ValueSource(strings = {"simple_user_task_process_with_taskana_prefix", "simple_user_task_process_with_both_prefixes"})
+  void should_HandlePrefixesCorrectly_When_StartCamundaTaskWithPrefixes(String processDefinitionKey)
+      throws Exception {
+    String processInstanceId =
+        this.camundaProcessengineRequester.startCamundaProcessAndReturnId(processDefinitionKey, "");
+    List<String> camundaTaskIds =
+        this.camundaProcessengineRequester.getTaskIdsFromProcessInstanceId(processInstanceId);
+
+    Thread.sleep((long) (this.adapterTaskPollingInterval * 1.2));
+
+    for (String camundaTaskId : camundaTaskIds) {
+      List<TaskSummary> kadaiTasks =
+          this.taskService.createTaskQuery().externalIdIn(camundaTaskId).list();
+      assertThat(kadaiTasks).hasSize(1);
+      TaskSummary kadaiTaskSummary = kadaiTasks.get(0);
+      String kadaiTaskExternalId = kadaiTaskSummary.getExternalId();
+      assertThat(kadaiTaskExternalId).isEqualTo(camundaTaskId);
+      String businessProcessId = kadaiTaskSummary.getBusinessProcessId();
+      assertThat(processInstanceId).isEqualTo(businessProcessId);
+      assertThat(kadaiTaskSummary.getClassificationSummary().getKey()).isEqualTo("L1050");
+
+      String expectedPrimitiveVariable1 =
+          "{\"valueInfo\":null,\"type\":\"string\",\"value\":\"TestItem\"}";
+      String expectedPrimitiveVariable2 =
+          "{\"valueInfo\":null,\"type\":\"string\",\"value\":\"42\"}";
+
+      Map<String, String> customAttributes =
+          retrieveCustomAttributesFromNewKadaiTask(camundaTaskId);
+      assertThat(
+          expectedPrimitiveVariable1,
+          SameJSONAs.sameJSONAs(customAttributes.get("camunda:item")));
+      assertThat(
+          expectedPrimitiveVariable2, SameJSONAs.sameJSONAs(customAttributes.get("camunda:amount")));
+    }
+
+    Instant lastRunTime = lastSchedulerRun.getLastRunTime();
+    assertThat(lastRunTime).isNotNull();
+    assertThat(lastRunTime).isAfter(Instant.now().minusSeconds(5));
   }
 
   private void setSystemConnector(String systemEngineIdentifier) {


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: