### PR TITLE
Closes #146 - Make both Kadai And Taskana attributes from the process model readable

### DIFF
--- a/camunda-outbox-example-boot/pom.xml
+++ b/camunda-outbox-example-boot/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.kadai</groupId>
         <artifactId>kadai-adapter-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/ci/kadai-adapter-sonar-test-coverage/pom.xml
+++ b/ci/kadai-adapter-sonar-test-coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.kadai</groupId>
         <artifactId>kadai-adapter-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/kadai-adapter-camunda-listener-example/pom.xml
+++ b/kadai-adapter-camunda-listener-example/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.kadai</groupId>
         <artifactId>kadai-adapter-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/kadai-adapter-camunda-listener/pom.xml
+++ b/kadai-adapter-camunda-listener/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>io.kadai</groupId>
     <artifactId>kadai-adapter-parent</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>

--- a/kadai-adapter-camunda-outbox-rest-spring-boot-starter/pom.xml
+++ b/kadai-adapter-camunda-outbox-rest-spring-boot-starter/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.kadai</groupId>
         <artifactId>kadai-adapter-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kadai-adapter-camunda-outbox-rest/pom.xml
+++ b/kadai-adapter-camunda-outbox-rest/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.kadai</groupId>
         <artifactId>kadai-adapter-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>

--- a/kadai-adapter-camunda-spring-boot-example/pom.xml
+++ b/kadai-adapter-camunda-spring-boot-example/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.kadai</groupId>
         <artifactId>kadai-adapter-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kadai-adapter-camunda-spring-boot-example/src/main/resources/application.properties
+++ b/kadai-adapter-camunda-spring-boot-example/src/main/resources/application.properties
@@ -57,10 +57,10 @@ kadai.adapter.mapping.default.objectreference.system.instance=DEFAULT_SYSTEM_INS
 kadai.adapter.mapping.default.objectreference.type=DEFAULT_TYPE
 kadai.adapter.mapping.default.objectreference.value=DEFAULT_VALUE
 management.endpoints.web.exposure.include= *
-management.endpoint.health.show-details= always
-management.health.external-services.include=external-services
-management.health.external-services.enabled=true
+management.endpoint.health.show-details=always
+#management.health.external-services.enabled=false
+#management.health.external-services.camunda.enabled=false
 camundaOutboxService.port=8081
 camundaOutboxService.address=http://localhost
-outbox.context-path:example-context-root
+outbox.context-path=example-context-root
 #kadai.adapter.xsrf.token=KAD_UNIQUE_TOKEN_123

--- a/kadai-adapter-camunda-spring-boot-test/pom.xml
+++ b/kadai-adapter-camunda-spring-boot-test/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.kadai</groupId>
         <artifactId>kadai-adapter-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kadai-adapter-camunda-spring-boot-test/src/main/resources/processes/simple_user_task_process_with_both_prefixes.bpmn
+++ b/kadai-adapter-camunda-spring-boot-test/src/main/resources/processes/simple_user_task_process_with_both_prefixes.bpmn
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_both_prefixes" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <bpmn:process id="simple_user_task_process_with_both_prefixes" isExecutable="true">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="kadai.domain" value="DOMAIN_A" />
+        <camunda:property name="taskana.domain" value="DOMAIN_A" />
+        <camunda:property name="kadai-attributes" value="amount,item" />
+        <camunda:property name="taskana-attributes" value="amount,item" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="UserTask_1" name="UserTask1">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="kadai.classification-key" value="L1050" />
+          <camunda:property name="taskana.classification-key" value="L9999" />
+        </camunda:properties>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="amount">42</camunda:inputParameter>
+          <camunda:inputParameter name="item">TestItem</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="UserTask_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="UserTask_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="simple_user_task_process_with_both_prefixes">
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="200" y="100" />
+        <di:waypoint x="300" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="400" y="100" />
+        <di:waypoint x="500" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="164" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_1_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="300" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="500" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions> 

--- a/kadai-adapter-camunda-spring-boot-test/src/main/resources/processes/simple_user_task_process_with_taskana_prefix.bpmn
+++ b/kadai-adapter-camunda-spring-boot-test/src/main/resources/processes/simple_user_task_process_with_taskana_prefix.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_taskana_prefix" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <bpmn:process id="simple_user_task_process_with_taskana_prefix" isExecutable="true">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="taskana.domain" value="DOMAIN_A" />
+        <camunda:property name="taskana-attributes" value="amount,item" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="UserTask_1" name="UserTask1">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="taskana.classification-key" value="L1050" />
+        </camunda:properties>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="amount">42</camunda:inputParameter>
+          <camunda:inputParameter name="item">TestItem</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="UserTask_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="UserTask_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="simple_user_task_process_with_taskana_prefix">
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="200" y="100" />
+        <di:waypoint x="300" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="400" y="100" />
+        <di:waypoint x="500" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="164" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_1_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="300" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="500" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions> 

--- a/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/CamundaHealthCheckTest.java
+++ b/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/CamundaHealthCheckTest.java
@@ -1,140 +1,76 @@
 package io.kadai.adapter.integration;
 
-import static io.kadai.adapter.integration.HealthCheckEndpoints.CAMUNDA_ENGINE_ENDPOINT;
-import static io.kadai.adapter.integration.HealthCheckEndpoints.HEALTH_ENDPOINT;
-import static io.kadai.adapter.integration.HealthCheckEndpoints.OUTBOX_EVENTS_COUNT_ENDPOINT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
+import io.kadai.adapter.models.CamundaEngineInfoRepresentationModel;
 import io.kadai.adapter.monitoring.CamundaHealthCheck;
-import io.kadai.adapter.monitoring.SchedulerHealthCheck;
-import io.kadai.adapter.test.KadaiAdapterTestApplication;
-import io.kadai.common.test.security.JaasExtension;
-import io.kadai.common.test.security.WithAccessId;
-import java.time.Duration;
-import java.time.Instant;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
+import java.util.Arrays;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.http.HttpMethod;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.springframework.boot.actuate.health.Status;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.web.client.ExpectedCount;
-import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
-@SpringBootTest(
-    classes = KadaiAdapterTestApplication.class,
-    webEnvironment = WebEnvironment.DEFINED_PORT)
-@AutoConfigureWebTestClient
-@ExtendWith(JaasExtension.class)
-@ContextConfiguration
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class CamundaHealthCheckTest extends AbsIntegrationTest {
+class CamundaHealthCheckTest {
 
-  @Autowired private SchedulerHealthCheck schedulerHealthIndicator;
-
-  private MockRestServiceServer mockServer;
-
-  @Autowired private RestTemplate restTemplate;
-
-  @Autowired private CamundaHealthCheck camundaHealthIndicator;
-
-  @Autowired private TestRestTemplate testRestTemplate;
+  private CamundaHealthCheck camundaHealthCheckSpy;
+  private RestTemplate restTemplate;
 
   @BeforeEach
-  @WithAccessId(user = "admin")
-  void setUp() throws Exception {
-    mockServer = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true).build();
-
-    SchedulerHealthCheck spySchedulerHealthCheck = schedulerHealthIndicator;
-    Instant validRunTime = Instant.now().minus(Duration.ofMinutes(5));
-    when(spySchedulerHealthCheck.health())
-        .thenReturn(Health.up().withDetail("Last Run", validRunTime).build());
-  }
-
-  @AfterEach
-  void tearDown() {
-    mockServer.reset();
-  }
-
-  @AfterAll
-  void triggerSetUp() {
-    isInitialised = false;
+  void setUp() {
+    this.restTemplate = Mockito.mock(RestTemplate.class);
+    this.camundaHealthCheckSpy =
+        Mockito.spy(
+            new CamundaHealthCheck(restTemplate, "http://localhost", 8090, "example-context-root"));
   }
 
   @Test
-  void should_ReturnUp_When_CamundaServiceIsHealthy() {
-    mockServer
-        .expect(ExpectedCount.manyTimes(), requestTo(CAMUNDA_ENGINE_ENDPOINT))
-        .andExpect(method(HttpMethod.GET))
-        .andRespond(withSuccess("[{\"name\": \"default\"}]", MediaType.APPLICATION_JSON));
-    dummyOutboxMock();
+  void should_ReturnUp_When_CamundaRespondsSuccessfully() {
+    when(restTemplate.<CamundaEngineInfoRepresentationModel[]>getForEntity(any(), any()))
+        .thenReturn(
+            ResponseEntity.ok()
+                .body(
+                    new CamundaEngineInfoRepresentationModel[] {
+                      new CamundaEngineInfoRepresentationModel()
+                    }));
 
-    ResponseEntity<String> response = testRestTemplate.getForEntity(HEALTH_ENDPOINT, String.class);
-
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody())
-        .contains("\"Camunda Health\":{\"status\":\"UP\"")
-        .contains("\"Camunda Engines\":[{\"name\":\"default\"}]");
+    assertThat(camundaHealthCheckSpy.health().getStatus()).isEqualTo(Status.UP);
   }
 
   @Test
-  void should_ReturnDown_When_CheckingCamundaEngineHealth() {
-    mockServer
-        .expect(ExpectedCount.manyTimes(), requestTo(CAMUNDA_ENGINE_ENDPOINT))
-        .andExpect(method(HttpMethod.GET))
-        .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
-    dummyOutboxMock();
+  void should_ReturnDown_When_CamundaRespondsSuccessfullyButListsNoEngines() {
+    when(restTemplate.<CamundaEngineInfoRepresentationModel[]>getForEntity(any(), any()))
+        .thenReturn(ResponseEntity.ok().body(new CamundaEngineInfoRepresentationModel[] {}));
 
-    ResponseEntity<String> response = testRestTemplate.getForEntity(HEALTH_ENDPOINT, String.class);
+    assertThat(camundaHealthCheckSpy.health().getStatus()).isEqualTo(Status.DOWN);
+  }
 
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-    assertThat(response.getBody())
-        .contains("\"Camunda Health\":{\"status\":\"DOWN\"")
-        .contains("\"Camunda Engine Error\":\"No engines found\"");
+  @ParameterizedTest
+  @MethodSource("errorResponseProvider")
+  void should_ReturnDown_When_CamundaRespondsWithError(HttpStatus httpStatus) {
+    when(restTemplate.<CamundaEngineInfoRepresentationModel[]>getForEntity(any(), any()))
+        .thenReturn(ResponseEntity.status(httpStatus).build());
+
+    assertThat(camundaHealthCheckSpy.health().getStatus()).isEqualTo(Status.DOWN);
   }
 
   @Test
-  void should_ThrowException_When_CheckingCamundaEngineHealth() {
-    mockServer
-        .expect(ExpectedCount.manyTimes(), requestTo(CAMUNDA_ENGINE_ENDPOINT))
-        .andExpect(method(HttpMethod.GET))
-        .andRespond(
-            withStatus(HttpStatus.NOT_FOUND)
-                .body("Page Not Found")
-                .contentType(MediaType.TEXT_PLAIN));
-    dummyOutboxMock();
+  void should_ReturnDown_When_CamundaPingFails() {
+    when(restTemplate.<CamundaEngineInfoRepresentationModel[]>getForEntity(any(), any()))
+        .thenThrow(new RuntimeException("foo"));
 
-    ResponseEntity<String> response = testRestTemplate.getForEntity(HEALTH_ENDPOINT, String.class);
-
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-    assertThat(response.getBody())
-        .contains("\"Camunda Health\":{\"status\":\"DOWN\"")
-        .contains("\"Camunda Engine Error\":");
+    assertThat(camundaHealthCheckSpy.health().getStatus()).isEqualTo(Status.DOWN);
   }
 
-  private void dummyOutboxMock() {
-    this.mockServer
-        .expect(ExpectedCount.manyTimes(), requestTo(OUTBOX_EVENTS_COUNT_ENDPOINT))
-        .andExpect(method(HttpMethod.GET))
-        .andRespond(withSuccess("{\"eventsCount\": 5}", MediaType.APPLICATION_JSON));
+  private static Stream<Arguments> errorResponseProvider() {
+    return Arrays.stream(HttpStatus.values()).filter(HttpStatus::isError).map(Arguments::of);
   }
 }

--- a/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/KadaiHealthCheckTest.java
+++ b/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/KadaiHealthCheckTest.java
@@ -1,114 +1,38 @@
 package io.kadai.adapter.integration;
 
-import static io.kadai.adapter.integration.HealthCheckEndpoints.HEALTH_ENDPOINT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.kadai.adapter.monitoring.KadaiHealthCheck;
-import io.kadai.adapter.monitoring.SchedulerHealthCheck;
-import io.kadai.adapter.test.KadaiAdapterTestApplication;
-import io.kadai.common.test.security.JaasExtension;
-import java.time.Duration;
-import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.context.annotation.Bean;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ContextConfiguration;
 
-@SpringBootTest(
-    classes = KadaiAdapterTestApplication.class,
-    webEnvironment = WebEnvironment.DEFINED_PORT)
-@AutoConfigureWebTestClient
-@ExtendWith(JaasExtension.class)
-@ContextConfiguration
-class KadaiHealthCheckTest extends AbsIntegrationTest {
+class KadaiHealthCheckTest {
 
-  @TestConfiguration
-  static class TestConfig {
-    @Bean
-    KadaiHealthCheck kadaiHealthCheck() throws Exception {
-      KadaiHealthCheck realHealthCheck = new KadaiHealthCheck();
-      KadaiHealthCheck spyHealthCheck = Mockito.spy(realHealthCheck);
-
-      return spyHealthCheck;
-    }
-  }
-
-  @Autowired private SchedulerHealthCheck schedulerHealthIndicator;
-
-  @Autowired private KadaiHealthCheck kadaiHealthIndicator;
-
-  @Autowired private TestRestTemplate testRestTemplate;
-
-  private KadaiHealthCheck spyHealthCheck;
+  private KadaiHealthCheck kadaiHealthCheckSpy;
 
   @BeforeEach
   void setUp() {
-    spyHealthCheck = kadaiHealthIndicator;
-    SchedulerHealthCheck spySchedulerHealthCheck = schedulerHealthIndicator;
-    Instant validRunTime = Instant.now().minus(Duration.ofMinutes(5));
-    when(spySchedulerHealthCheck.health())
-        .thenReturn(Health.up().withDetail("Last Run", validRunTime).build());
+    this.kadaiHealthCheckSpy = Mockito.spy(new KadaiHealthCheck());
   }
 
   @Test
-  void should_ReturnUp_When_ReturnValidSchemaVersion() throws Exception {
-    KadaiHealthCheck kadaiHealthCheck = new KadaiHealthCheck();
-    KadaiHealthCheck spy = Mockito.spy(kadaiHealthCheck);
-
-    when(spy.getCurrentSchemaVersion()).thenReturn("1.0.0");
+  void should_ReturnUp_When_ReturnValidSchemaVersion() {
+    when(kadaiHealthCheckSpy.getCurrentSchemaVersion()).thenReturn("1.0.0");
 
     Health health = Health.up().withDetail("Kadai Version", "1.0.0").build();
-    assertThat(spy.health()).isEqualTo(health);
+    assertThat(kadaiHealthCheckSpy.health()).isEqualTo(health);
   }
 
   @Test
-  void should_ReturnDown_When_ExceptionThrownForSchemaVersion() throws Exception {
-    KadaiHealthCheck kadaiHealthCheck = new KadaiHealthCheck();
-    KadaiHealthCheck spy = Mockito.spy(kadaiHealthCheck);
-
+  void should_ReturnDown_When_ExceptionThrownForSchemaVersion() {
     Mockito.doThrow(new RuntimeException("Simulated exception"))
-        .when(spy)
+        .when(kadaiHealthCheckSpy)
         .getCurrentSchemaVersion();
 
     Health health = Health.down().withDetail("Kadai Service Error", "Simulated exception").build();
-    assertThat(spy.health()).isEqualTo(health);
-  }
-
-  @Test
-  void should_ReturnUp_When_CallingHealthEndpoint() {
-    when(spyHealthCheck.health())
-        .thenReturn(Health.up().withDetail("Kadai Version", "1.0.0").build());
-
-    ResponseEntity<String> response =
-        testRestTemplate.getForEntity(
-            HEALTH_ENDPOINT, String.class);
-
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody()).contains("Kadai Version", "1.0.0");
-  }
-
-  @Test
-  void should_ReturnDown_When_CallingHealthEndpoint() {
-    when(spyHealthCheck.health())
-        .thenReturn(Health.down().withDetail("Kadai Service Error", "Simulated failure").build());
-
-    ResponseEntity<String> response =
-        testRestTemplate.getForEntity(
-            HEALTH_ENDPOINT, String.class);
-
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-    assertThat(response.getBody()).contains("Kadai Service Error", "Simulated failure");
+    assertThat(kadaiHealthCheckSpy.health()).isEqualTo(health);
   }
 }

--- a/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/OutboxHealthCheckTest.java
+++ b/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/OutboxHealthCheckTest.java
@@ -1,142 +1,63 @@
 package io.kadai.adapter.integration;
 
-import static io.kadai.adapter.integration.HealthCheckEndpoints.CAMUNDA_ENGINE_ENDPOINT;
-import static io.kadai.adapter.integration.HealthCheckEndpoints.HEALTH_ENDPOINT;
-import static io.kadai.adapter.integration.HealthCheckEndpoints.OUTBOX_EVENTS_COUNT_ENDPOINT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-import io.kadai.adapter.monitoring.CamundaHealthCheck;
-import io.kadai.adapter.monitoring.SchedulerHealthCheck;
-import io.kadai.adapter.test.KadaiAdapterTestApplication;
-import io.kadai.common.test.security.JaasExtension;
-import io.kadai.common.test.security.WithAccessId;
-import java.time.Duration;
-import java.time.Instant;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
+import io.kadai.adapter.models.OutboxEventCountRepresentationModel;
+import io.kadai.adapter.monitoring.OutboxHealthCheck;
+import java.util.Arrays;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.http.HttpMethod;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.springframework.boot.actuate.health.Status;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.web.client.ExpectedCount;
-import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
-@SpringBootTest(
-    classes = KadaiAdapterTestApplication.class,
-    webEnvironment = WebEnvironment.DEFINED_PORT)
-@AutoConfigureWebTestClient
-@ExtendWith(JaasExtension.class)
-@ContextConfiguration
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class OutboxHealthCheckTest extends AbsIntegrationTest {
+class OutboxHealthCheckTest {
 
-  @Autowired private SchedulerHealthCheck schedulerHealthIndicator;
-  private MockRestServiceServer mockServer;
-
-  @Autowired private RestTemplate restTemplate;
-
-  @Autowired private CamundaHealthCheck camundaHealthIndicator;
-
-  @Autowired private TestRestTemplate testRestTemplate;
+  private OutboxHealthCheck outboxHealthCheckSpy;
+  private RestTemplate restTemplate;
 
   @BeforeEach
-  @WithAccessId(user = "admin")
-  void setUp() throws Exception {
-    mockServer = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true).build();
-    SchedulerHealthCheck spySchedulerHealthCheck = schedulerHealthIndicator;
-    Instant validRunTime = Instant.now().minus(Duration.ofMinutes(5));
-    when(spySchedulerHealthCheck.health())
-        .thenReturn(Health.up().withDetail("Last Run", validRunTime).build());
-  }
-
-  @AfterEach
-  void tearDown() {
-    mockServer.reset();
-  }
-
-  @AfterAll
-  void triggerSetUp() {
-    isInitialised = false;
+  void setUp() {
+    this.restTemplate = Mockito.mock(RestTemplate.class);
+    this.outboxHealthCheckSpy =
+        Mockito.spy(
+            new OutboxHealthCheck(restTemplate, "http://localhost", 8090, "example-context-root"));
   }
 
   @Test
-  void should_ReturnUp_When_OutboxServiceIsHealthy() {
-    mockServer
-        .expect(ExpectedCount.manyTimes(), requestTo(OUTBOX_EVENTS_COUNT_ENDPOINT))
-        .andExpect(method(HttpMethod.GET))
-        .andRespond(withSuccess("{\"eventsCount\": 5}", MediaType.APPLICATION_JSON));
-    dummyCamundaEngineMock();
+  void should_ReturnUp_When_OutboxRespondsSuccessfully() {
+    when(restTemplate.<OutboxEventCountRepresentationModel>getForEntity(any(), any()))
+        .thenReturn(ResponseEntity.ok().body(new OutboxEventCountRepresentationModel()));
 
-    ResponseEntity<String> response = testRestTemplate.getForEntity(HEALTH_ENDPOINT, String.class);
+    assertThat(outboxHealthCheckSpy.health().getStatus()).isEqualTo(Status.UP);
+  }
 
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody())
-        .contains("\"Outbox Health\":{\"status\":\"UP\"")
-        .contains("\"Outbox Service\":{\"eventsCount\":5}");
+  @ParameterizedTest
+  @MethodSource("errorResponseProvider")
+  void should_ReturnDown_When_OutboxRespondsWithError(HttpStatus httpStatus) {
+    when(restTemplate.<OutboxEventCountRepresentationModel>getForEntity(any(), any()))
+        .thenReturn(ResponseEntity.status(httpStatus).build());
+
+    assertThat(outboxHealthCheckSpy.health().getStatus()).isEqualTo(Status.DOWN);
   }
 
   @Test
-  void should_ReturnDown_When_ReturnOtherStatusCode() {
-    // should return down when status code is not 200
-    mockServer
-        .expect(ExpectedCount.manyTimes(), requestTo(OUTBOX_EVENTS_COUNT_ENDPOINT))
-        .andExpect(method(HttpMethod.GET))
-        .andRespond(
-            withStatus(HttpStatus.ACCEPTED)
-                .body("{\"eventsCount\": 5}")
-                .contentType(MediaType.APPLICATION_JSON));
-    dummyCamundaEngineMock();
+  void should_ReturnDown_When_OutboxPingFails() {
+    when(restTemplate.<OutboxEventCountRepresentationModel>getForEntity(any(), any()))
+        .thenThrow(new RuntimeException("foo"));
 
-    ResponseEntity<String> response = testRestTemplate.getForEntity(HEALTH_ENDPOINT, String.class);
-
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-    assertThat(response.getBody())
-        .contains("\"Outbox Health\":{\"status\":\"DOWN\"")
-        .contains("\"Outbox Service Error\":\"Unexpected status: 202 ACCEPTED\"");
+    assertThat(outboxHealthCheckSpy.health().getStatus()).isEqualTo(Status.DOWN);
   }
 
-  @Test
-  void should_ThrowException_When_ReturnOtherStatusCode() {
-    // should return when an exception is catched
-    mockServer
-        .expect(ExpectedCount.manyTimes(), requestTo(OUTBOX_EVENTS_COUNT_ENDPOINT))
-        .andExpect(method(HttpMethod.GET))
-        .andRespond(
-            withStatus(HttpStatus.NOT_FOUND)
-                .body("Page Not Found")
-                .contentType(MediaType.TEXT_PLAIN));
-    dummyCamundaEngineMock();
-
-    ResponseEntity<String> response = testRestTemplate.getForEntity(HEALTH_ENDPOINT, String.class);
-
-    assertThat(response.getBody())
-        .contains("\"Outbox Health\":{\"status\":\"DOWN\"")
-        .contains("\"Outbox Service Error\":");
-  }
-
-  private void dummyCamundaEngineMock() {
-    mockServer
-        .expect(ExpectedCount.manyTimes(), requestTo(CAMUNDA_ENGINE_ENDPOINT))
-        .andExpect(method(HttpMethod.GET))
-        .andRespond(withSuccess("[{\"name\": \"default\"}]", MediaType.APPLICATION_JSON));
+  private static Stream<Arguments> errorResponseProvider() {
+    return Arrays.stream(HttpStatus.values()).filter(HttpStatus::isError).map(Arguments::of);
   }
 }

--- a/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/SchedulerHealthCheckTest.java
+++ b/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/SchedulerHealthCheckTest.java
@@ -1,114 +1,47 @@
 package io.kadai.adapter.integration;
 
-import static io.kadai.adapter.integration.HealthCheckEndpoints.HEALTH_ENDPOINT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.kadai.adapter.impl.LastSchedulerRun;
 import io.kadai.adapter.monitoring.SchedulerHealthCheck;
-import io.kadai.adapter.test.KadaiAdapterTestApplication;
-import io.kadai.common.test.security.JaasExtension;
 import java.time.Duration;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.context.annotation.Bean;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ContextConfiguration;
 
-@SpringBootTest(
-    classes = KadaiAdapterTestApplication.class,
-    webEnvironment = WebEnvironment.DEFINED_PORT)
-@AutoConfigureWebTestClient
-@ExtendWith(JaasExtension.class)
-@ContextConfiguration
-class SchedulerHealthCheckTest extends AbsIntegrationTest {
+class SchedulerHealthCheckTest {
 
-  @TestConfiguration
-  static class TestConfig {
-    @Bean
-    SchedulerHealthCheck schedulerHealthCheck() throws Exception {
-      LastSchedulerRun lastSchedulerRunMock = Mockito.mock(LastSchedulerRun.class);
-      Instant dummyRunTime = Instant.now().minus(Duration.ofMinutes(10));
-      when(lastSchedulerRunMock.getLastRunTime()).thenReturn(dummyRunTime);
-
-      SchedulerHealthCheck realHealthCheck = new SchedulerHealthCheck(lastSchedulerRunMock);
-      SchedulerHealthCheck spyHealthCheck = Mockito.spy(realHealthCheck);
-
-      return spyHealthCheck;
-    }
-  }
-
-  @Autowired private SchedulerHealthCheck schedulerHealthIndicator;
-
-  @Autowired private TestRestTemplate testRestTemplate;
-
-  private SchedulerHealthCheck spyHealthCheck;
+  private SchedulerHealthCheck schedulerHealthCheckSpy;
+  private LastSchedulerRun lastSchedulerRunSpy;
 
   @BeforeEach
   void setUp() {
-    spyHealthCheck = schedulerHealthIndicator;
+    this.lastSchedulerRunSpy = Mockito.spy(new LastSchedulerRun());
+    this.schedulerHealthCheckSpy = Mockito.spy(new SchedulerHealthCheck(lastSchedulerRunSpy));
   }
 
   @Test
-  void should_ReturnUp_When_SchedulerRuns() throws Exception {
-    LastSchedulerRun spy = Mockito.spy(new LastSchedulerRun());
+  void should_ReturnUp_When_SchedulerRuns() {
     Instant validRunTime = Instant.now().minus(Duration.ofMinutes(5));
-    when(spy.getLastRunTime()).thenReturn(validRunTime);
+    when(lastSchedulerRunSpy.getLastRunTime()).thenReturn(validRunTime);
 
-    SchedulerHealthCheck schedulerHealthCheck = new SchedulerHealthCheck(spy);
-    Health health = Health.up().withDetail("Last Run", spy.getLastRunTime()).build();
+    Health health =
+        Health.up().withDetail("Last Run", lastSchedulerRunSpy.getLastRunTime()).build();
 
-    assertThat(schedulerHealthCheck.health()).isEqualTo(health);
+    assertThat(schedulerHealthCheckSpy.health()).isEqualTo(health);
   }
 
   @Test
   void should_ReturnDown_When_SchedulerDoesNotRun() {
-    LastSchedulerRun spy = Mockito.spy(new LastSchedulerRun());
     Instant invalidRunTime = Instant.now().minus(Duration.ofMinutes(15));
-    when(spy.getLastRunTime()).thenReturn(invalidRunTime);
+    when(lastSchedulerRunSpy.getLastRunTime()).thenReturn(invalidRunTime);
 
-    SchedulerHealthCheck schedulerHealthCheck = new SchedulerHealthCheck(spy);
-    Health health = Health.down().withDetail("Last Run", spy.getLastRunTime()).build();
+    Health health =
+        Health.down().withDetail("Last Run", lastSchedulerRunSpy.getLastRunTime()).build();
 
-    assertThat(schedulerHealthCheck.health()).isEqualTo(health);
-  }
-
-  @Test
-  void should_ReturnUp_When_CallingHealthEndpoint() {
-    Instant validRunTime = Instant.now().minus(Duration.ofMinutes(5));
-    when(spyHealthCheck.health())
-        .thenReturn(Health.up().withDetail("Last Run", validRunTime).build());
-
-    ResponseEntity<String> response =
-        testRestTemplate.getForEntity(
-            HEALTH_ENDPOINT, String.class);
-
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody()).contains("Last Run", validRunTime.toString());
-  }
-
-  @Test
-  void should_ReturnDown_When_CallingHealthEndpoint() {
-    Instant validRunTime = Instant.now().minus(Duration.ofMinutes(15));
-    when(spyHealthCheck.health())
-        .thenReturn(Health.down().withDetail("Last Run", validRunTime).build());
-
-    ResponseEntity<String> response =
-        testRestTemplate.getForEntity(
-            HEALTH_ENDPOINT, String.class);
-
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-    assertThat(response.getBody()).contains("Last Run", validRunTime.toString());
+    assertThat(schedulerHealthCheckSpy.health()).isEqualTo(health);
   }
 }

--- a/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/TestTaskAcquisition.java
+++ b/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/adapter/integration/TestTaskAcquisition.java
@@ -51,6 +51,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.ThrowingConsumer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,8 +75,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TestTaskAcquisition.class);
   @Autowired AdapterManager adapterManager;
-  @Autowired
-  private LastSchedulerRun lastSchedulerRun;
+  @Autowired private LastSchedulerRun lastSchedulerRun;
 
   @Value("${kadai-system-connector-camundaSystemURLs}")
   private String configuredSystemConnectorUrls;
@@ -166,9 +167,8 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void
-      should_CreateKadaiTask_When_StartUserTaskProcessInstanceWithEmptyExtensionPropertyInCamunda()
-          throws Exception {
+  void should_CreateKadaiTask_When_StartUserTaskProcessInstanceWithEmptyExtensionPropertyInCamunda()
+      throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -298,8 +298,7 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       throws Exception {
 
     String variables =
-        "\"variables\": {\"kadai.manual-priority\": {\"value\":\"555\", "
-            + "\"type\":\"string\"}}";
+        "\"variables\": {\"kadai.manual-priority\": {\"value\":\"555\", " + "\"type\":\"string\"}}";
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
             "simple_user_task_process", variables);
@@ -318,9 +317,8 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void
-      should_CreateKadaiTaskWithDefaultManualPriority_When_StartCamundaTaskWithoutManualPriority()
-          throws Exception {
+  void should_CreateKadaiTaskWithDefaultManualPriority_When_StartCamundaTaskWithoutManualPriority()
+      throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -610,9 +608,8 @@ class TestTaskAcquisition extends AbsIntegrationTest {
       user = "teamlead_1",
       groups = {"taskadmin"})
   @Test
-  void
-      should_CreateKadaiTasksWithCorrectDomains_When_StartProcessWithDomainsInExtensionProperties()
-          throws Exception {
+  void should_CreateKadaiTasksWithCorrectDomains_When_StartProcessWithDomainsInExtensionProperties()
+      throws Exception {
 
     String processInstanceId =
         this.camundaProcessengineRequester.startCamundaProcessAndReturnId(
@@ -831,6 +828,50 @@ class TestTaskAcquisition extends AbsIntegrationTest {
         };
 
     return DynamicTest.stream(input, Pair::getLeft, test);
+  }
+
+  @WithAccessId(
+      user = "teamlead_1",
+      groups = {"taskadmin"})
+  @ParameterizedTest
+  @ValueSource(strings = {"simple_user_task_process_with_taskana_prefix", "simple_user_task_process_with_both_prefixes"})
+  void should_HandlePrefixesCorrectly_When_StartCamundaTaskWithPrefixes(String processDefinitionKey)
+      throws Exception {
+    String processInstanceId =
+        this.camundaProcessengineRequester.startCamundaProcessAndReturnId(processDefinitionKey, "");
+    List<String> camundaTaskIds =
+        this.camundaProcessengineRequester.getTaskIdsFromProcessInstanceId(processInstanceId);
+
+    Thread.sleep((long) (this.adapterTaskPollingInterval * 1.2));
+
+    for (String camundaTaskId : camundaTaskIds) {
+      List<TaskSummary> kadaiTasks =
+          this.taskService.createTaskQuery().externalIdIn(camundaTaskId).list();
+      assertThat(kadaiTasks).hasSize(1);
+      TaskSummary kadaiTaskSummary = kadaiTasks.get(0);
+      String kadaiTaskExternalId = kadaiTaskSummary.getExternalId();
+      assertThat(kadaiTaskExternalId).isEqualTo(camundaTaskId);
+      String businessProcessId = kadaiTaskSummary.getBusinessProcessId();
+      assertThat(processInstanceId).isEqualTo(businessProcessId);
+      assertThat(kadaiTaskSummary.getClassificationSummary().getKey()).isEqualTo("L1050");
+
+      String expectedPrimitiveVariable1 =
+          "{\"valueInfo\":null,\"type\":\"string\",\"value\":\"TestItem\"}";
+      String expectedPrimitiveVariable2 =
+          "{\"valueInfo\":null,\"type\":\"string\",\"value\":\"42\"}";
+
+      Map<String, String> customAttributes =
+          retrieveCustomAttributesFromNewKadaiTask(camundaTaskId);
+      assertThat(
+          expectedPrimitiveVariable1,
+          SameJSONAs.sameJSONAs(customAttributes.get("camunda:item")));
+      assertThat(
+          expectedPrimitiveVariable2, SameJSONAs.sameJSONAs(customAttributes.get("camunda:amount")));
+    }
+
+    Instant lastRunTime = lastSchedulerRun.getLastRunTime();
+    assertThat(lastRunTime).isNotNull();
+    assertThat(lastRunTime).isAfter(Instant.now().minusSeconds(5));
   }
 
   private void setSystemConnector(String systemEngineIdentifier) {

--- a/kadai-adapter-camunda-system-connector/pom.xml
+++ b/kadai-adapter-camunda-system-connector/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.kadai</groupId>
         <artifactId>kadai-adapter-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kadai-adapter-camunda-wildfly-example/pom.xml
+++ b/kadai-adapter-camunda-wildfly-example/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.kadai</groupId>
         <artifactId>kadai-adapter-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kadai-adapter-kadai-connector/pom.xml
+++ b/kadai-adapter-kadai-connector/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.kadai</groupId>
         <artifactId>kadai-adapter-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kadai-adapter/pom.xml
+++ b/kadai-adapter/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.kadai</groupId>
         <artifactId>kadai-adapter-parent</artifactId>
-        <version>9.2.1-SNAPSHOT</version>
+        <version>9.3.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kadai-adapter/src/main/java/io/kadai/adapter/configuration/health/CompositeHealthContributorConfigurationProperties.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/configuration/health/CompositeHealthContributorConfigurationProperties.java
@@ -1,0 +1,14 @@
+package io.kadai.adapter.configuration.health;
+
+public class CompositeHealthContributorConfigurationProperties {
+
+  private Boolean enabled = true;
+
+  public Boolean getEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(Boolean enabled) {
+    this.enabled = enabled;
+  }
+}

--- a/kadai-adapter/src/main/java/io/kadai/adapter/configuration/health/ConfigurationPropertiesConfig.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/configuration/health/ConfigurationPropertiesConfig.java
@@ -1,0 +1,8 @@
+package io.kadai.adapter.configuration.health;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties
+public class ConfigurationPropertiesConfig {}

--- a/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/CamundaHealthCheck.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/CamundaHealthCheck.java
@@ -1,46 +1,32 @@
 package io.kadai.adapter.monitoring;
 
 import io.kadai.adapter.models.CamundaEngineInfoRepresentationModel;
-import jakarta.annotation.PostConstruct;
 import java.net.URI;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-@Component
 public class CamundaHealthCheck implements HealthIndicator {
 
   private final RestTemplate restTemplate;
-
-  @Value("${camundaOutboxService.address:http://localhost}")
-  private String camundaOutboxAddress;
-
-  @Value("${camundaOutboxService.port:8090}")
-  private int camundaOutboxPort;
-
-  @Value("${outbox.context-path:}")
-  private String contextPath;
+  private final String camundaOutboxAddress;
+  private final int camundaOutboxPort;
+  private final String contextPath;
 
   private URI url;
 
-  public CamundaHealthCheck(RestTemplate restTemplate) {
+  public CamundaHealthCheck(
+      RestTemplate restTemplate,
+      String camundaOutboxAddress,
+      int camundaOutboxPort,
+      String contextPath) {
     this.restTemplate = restTemplate;
-  }
-
-  @PostConstruct
-  public void init() {
-    this.url =
-        UriComponentsBuilder.fromUriString(camundaOutboxAddress)
-            .port(camundaOutboxPort)
-            .pathSegment(contextPath)
-            .pathSegment("engine-rest")
-            .pathSegment("engine")
-            .build()
-            .toUri();
+    this.camundaOutboxAddress = camundaOutboxAddress;
+    this.camundaOutboxPort = camundaOutboxPort;
+    this.contextPath = contextPath;
+    init();
   }
 
   @Override
@@ -58,9 +44,18 @@ public class CamundaHealthCheck implements HealthIndicator {
     }
   }
 
-  private ResponseEntity<CamundaEngineInfoRepresentationModel[]> pingCamundaRest()
-      throws Exception {
+  private void init() {
+    this.url =
+        UriComponentsBuilder.fromUriString(camundaOutboxAddress)
+            .port(camundaOutboxPort)
+            .pathSegment(contextPath)
+            .pathSegment("engine-rest")
+            .pathSegment("engine")
+            .build()
+            .toUri();
+  }
 
+  private ResponseEntity<CamundaEngineInfoRepresentationModel[]> pingCamundaRest() {
     return restTemplate.getForEntity(url, CamundaEngineInfoRepresentationModel[].class);
   }
 }

--- a/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/ExternalServicesHealthCheck.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/ExternalServicesHealthCheck.java
@@ -1,30 +1,51 @@
 package io.kadai.adapter.monitoring;
 
+import io.kadai.adapter.impl.LastSchedulerRun;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.CompositeHealthContributor;
 import org.springframework.boot.actuate.health.HealthContributor;
 import org.springframework.boot.actuate.health.NamedContributor;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
 
 @Component("external-services")
+@ConditionalOnEnabledHealthIndicator("external-services")
 public class ExternalServicesHealthCheck implements CompositeHealthContributor {
 
   private final Map<String, HealthContributor> healthContributors = new LinkedHashMap<>();
 
   @Autowired
   public ExternalServicesHealthCheck(
-      CamundaHealthCheck camundaHealthIndicator,
-      OutboxHealthCheck outboxHealthIndicator,
-      KadaiHealthCheck kadaiHealthIndicator,
-      SchedulerHealthCheck schedulerHealthCheck) {
-
-    healthContributors.put("Camunda Health", camundaHealthIndicator);
-    healthContributors.put("Outbox Health", outboxHealthIndicator);
-    healthContributors.put("Kadai Health", kadaiHealthIndicator);
-    healthContributors.put("Scheduler Health", schedulerHealthCheck);
+      ExternalServicesHealthConfigurationProperties properties,
+      RestTemplate restTemplate,
+      @Value("${camundaOutboxService.address:http://localhost}") String camundaOutboxAddress,
+      @Value("${camundaOutboxService.port:8090}") int camundaOutboxPort,
+      @Value("${outbox.context-path:}") String contextPath,
+      LastSchedulerRun lastSchedulerRun) {
+    if (properties.getCamunda().getEnabled()) {
+      healthContributors.put(
+          "camunda",
+          new CamundaHealthCheck(
+              restTemplate, camundaOutboxAddress, camundaOutboxPort, contextPath));
+    }
+    if (properties.getKadai().getEnabled()) {
+      healthContributors.put("kadai", new KadaiHealthCheck());
+    }
+    if (properties.getOutbox().getEnabled()) {
+      healthContributors.put(
+          "outbox",
+          new OutboxHealthCheck(
+              restTemplate, camundaOutboxAddress, camundaOutboxPort, contextPath));
+    }
+    if (properties.getScheduler().getEnabled()) {
+      healthContributors.put("scheduler", new SchedulerHealthCheck(lastSchedulerRun));
+    }
   }
 
   @Override
@@ -32,6 +53,7 @@ public class ExternalServicesHealthCheck implements CompositeHealthContributor {
     return healthContributors.get(name);
   }
 
+  @NonNull
   @Override
   public Iterator<NamedContributor<HealthContributor>> iterator() {
     return healthContributors.entrySet().stream()

--- a/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/ExternalServicesHealthConfigurationProperties.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/ExternalServicesHealthConfigurationProperties.java
@@ -1,0 +1,51 @@
+package io.kadai.adapter.monitoring;
+
+import io.kadai.adapter.configuration.health.CompositeHealthContributorConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "management.health.external-services")
+public class ExternalServicesHealthConfigurationProperties {
+
+  private CompositeHealthContributorConfigurationProperties camunda =
+      new CompositeHealthContributorConfigurationProperties();
+  private CompositeHealthContributorConfigurationProperties outbox =
+      new CompositeHealthContributorConfigurationProperties();
+  private CompositeHealthContributorConfigurationProperties kadai =
+      new CompositeHealthContributorConfigurationProperties();
+  private CompositeHealthContributorConfigurationProperties scheduler =
+      new CompositeHealthContributorConfigurationProperties();
+
+  public CompositeHealthContributorConfigurationProperties getCamunda() {
+    return camunda;
+  }
+
+  public void setCamunda(CompositeHealthContributorConfigurationProperties camunda) {
+    this.camunda = camunda;
+  }
+
+  public CompositeHealthContributorConfigurationProperties getOutbox() {
+    return outbox;
+  }
+
+  public void setOutbox(CompositeHealthContributorConfigurationProperties outbox) {
+    this.outbox = outbox;
+  }
+
+  public CompositeHealthContributorConfigurationProperties getKadai() {
+    return kadai;
+  }
+
+  public void setKadai(CompositeHealthContributorConfigurationProperties kadai) {
+    this.kadai = kadai;
+  }
+
+  public CompositeHealthContributorConfigurationProperties getScheduler() {
+    return scheduler;
+  }
+
+  public void setScheduler(CompositeHealthContributorConfigurationProperties scheduler) {
+    this.scheduler = scheduler;
+  }
+}

--- a/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/KadaiHealthCheck.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/KadaiHealthCheck.java
@@ -3,9 +3,7 @@ package io.kadai.adapter.monitoring;
 import io.kadai.KadaiConfiguration;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.stereotype.Component;
 
-@Component
 public class KadaiHealthCheck implements HealthIndicator {
 
   @Override
@@ -14,12 +12,11 @@ public class KadaiHealthCheck implements HealthIndicator {
       String version = getCurrentSchemaVersion();
       return Health.up().withDetail("Kadai Version", version).build();
     } catch (Exception e) {
-      Health health = Health.down().withDetail("Kadai Service Error", e.getMessage()).build();
-      return health;
+      return Health.down().withDetail("Kadai Service Error", e.getMessage()).build();
     }
   }
 
-  public String getCurrentSchemaVersion() throws Exception {
+  public String getCurrentSchemaVersion() {
     return KadaiConfiguration.class.getPackage().getImplementationVersion();
   }
 }

--- a/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/SchedulerHealthCheck.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/monitoring/SchedulerHealthCheck.java
@@ -5,10 +5,9 @@ import java.time.Duration;
 import java.time.Instant;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.stereotype.Component;
 
-@Component
 public class SchedulerHealthCheck implements HealthIndicator {
+
   private final LastSchedulerRun lastSchedulerRun;
 
   public SchedulerHealthCheck(LastSchedulerRun lastSchedulerRun) {
@@ -19,9 +18,8 @@ public class SchedulerHealthCheck implements HealthIndicator {
   public Health health() {
     Instant lastRunTime = lastSchedulerRun.getLastRunTime();
 
-    if (lastRunTime.isBefore(Instant.now().minus(Duration.ofMinutes(10)))) {
-      return Health.down().withDetail("Last Run", lastSchedulerRun.getLastRunTime()).build();
-    }
-    return Health.up().withDetail("Last Run", lastSchedulerRun.getLastRunTime()).build();
+    return lastRunTime.isBefore(Instant.now().minus(Duration.ofMinutes(10)))
+        ? Health.down().withDetail("Last Run", lastSchedulerRun.getLastRunTime()).build()
+        : Health.up().withDetail("Last Run", lastSchedulerRun.getLastRunTime()).build();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.kadai</groupId>
     <artifactId>kadai-adapter-parent</artifactId>
-    <version>9.2.1-SNAPSHOT</version>
+    <version>9.3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [ ] The corresponding ticket is in state `In Review`
- [ ] The corresponding ticket is attached to this Pull-Request
- [ ] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [ ] The changes pass the SonarQubeCloud-Quality-Gate
- [ ] If the documentation needs an update, following there's a link to it:
- [ ] If extra release-notes are required, they're listed indented below: