### PR TITLE
Closes #215 - Remove ancient C7 Kadai-Adapter-DB artifacts

### DIFF
--- a/kadai-adapter-camunda-spring-boot-test/src/main/resources/sql/clear-kadai-adapter-db.sql
+++ b/kadai-adapter-camunda-spring-boot-test/src/main/resources/sql/clear-kadai-adapter-db.sql
@@ -1,3 +1,0 @@
-SET SCHEMA TCA;
-delete from TASKS;
-delete from QUERY_HISTORY;

--- a/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/impl/configuration/DbCleaner.java
+++ b/kadai-adapter-camunda-spring-boot-test/src/test/java/io/kadai/impl/configuration/DbCleaner.java
@@ -34,7 +34,6 @@ public class DbCleaner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DbCleaner.class);
   private static final String KADAI_DB_CLEAR_SCRIPT = "/sql/clear-kadai-db.sql";
-  private static final String KADAI_ADAPTER_DB_CLEAR_SCRIPT = "/sql/clear-kadai-adapter-db.sql";
   private static final String CAMUNDA_DB_CLEAR_SCRIPT = "/sql/clear-camunda-db.sql";
   private static final String OUTBOX_DB_CLEAR_SCRIPT = "/sql/clear-outbox-db.sql";
   private static final String KADAI_ADAPTER_DB_CLEAR_POSTGRES =
@@ -51,7 +50,6 @@ public class DbCleaner {
 
   public DbCleaner() {
     this.typeScriptMap.put(ApplicationDatabaseType.KADAI, KADAI_DB_CLEAR_SCRIPT);
-    this.typeScriptMap.put(ApplicationDatabaseType.KADAI_ADAPTER, KADAI_ADAPTER_DB_CLEAR_SCRIPT);
     this.typeScriptMap.put(ApplicationDatabaseType.CAMUNDA, CAMUNDA_DB_CLEAR_SCRIPT);
     this.typeScriptMap.put(ApplicationDatabaseType.OUTBOX, OUTBOX_DB_CLEAR_SCRIPT);
 


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: