### PR TITLE
Closes #219 - C8: Add direct failure if an exception is thrown in a Job Worker 

### DIFF
--- a/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCompletion.java
+++ b/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCompletion.java
@@ -26,23 +26,15 @@ public class UserTaskCompletion {
   }
 
   @JobWorker(type = "kadai-receive-task-completed-event")
-  public void receiveTaskCompletedEvent(final ActivatedJob job) {
+  public void receiveTaskCompletedEvent(final ActivatedJob job)
+          throws TaskTerminationFailedException {
+    LOGGER.info(
+        "UserTaskListener kadai-receive-task-completed-event has been called, "
+        + "connected to process instance '{}'",
+        job.getProcessInstanceKey());
 
-    try {
-      LOGGER.info(
-          "UserTaskListener kadai-receive-task-completed-event has been called, "
-              + "connected to process instance '{}'",
-          job.getProcessInstanceKey());
-
-      ReferencedTask referencedTask = referencedTaskCreator.createReferencedTaskFromJob(job);
-      referencedTask.setTaskState(TASK_STATE_COMPLETED);
-      taskTerminator.terminateKadaiTask(referencedTask);
-
-    } catch (TaskTerminationFailedException e) {
-      LOGGER.error(
-          "Caught exception while trying to retrieve "
-              + "finished referenced tasks and terminate corresponding kadai tasks",
-          e);
-    }
+    ReferencedTask referencedTask = referencedTaskCreator.createReferencedTaskFromJob(job);
+    referencedTask.setTaskState(TASK_STATE_COMPLETED);
+    taskTerminator.terminateKadaiTask(referencedTask);
   }
 }

--- a/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCreation.java
+++ b/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCreation.java
@@ -25,23 +25,14 @@ public class UserTaskCreation {
   }
 
   @JobWorker(type = "kadai-receive-task-created-event")
-  public void receiveTaskCreatedEvent(final ActivatedJob job) {
+  public void receiveTaskCreatedEvent(final ActivatedJob job) throws TaskCreationFailedException {
+    LOGGER.info(
+        "UserTaskListener kadai-receive-task-created-event has been called, "
+        + "connected to process instance '{}'",
+        job.getProcessInstanceKey());
 
-    try {
-      LOGGER.info(
-          "UserTaskListener kadai-receive-task-created-event has been called, "
-              + "connected to process instance '{}'",
-          job.getProcessInstanceKey());
+    ReferencedTask referencedTask = referencedTaskCreator.createReferencedTaskFromJob(job);
 
-      ReferencedTask referencedTask = referencedTaskCreator.createReferencedTaskFromJob(job);
-
-      taskStarter.createKadaiTask(referencedTask);
-
-    } catch (TaskCreationFailedException e) {
-      LOGGER.error(
-          "Caught exception while trying to retrieve "
-              + "finished referenced tasks and terminate corresponding kadai tasks",
-          e);
-    }
+    taskStarter.createKadaiTask(referencedTask);
   }
 }


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [ ] The changes pass the SonarQubeCloud-Quality-Gate
- [ ] If the documentation needs an update, following there's a link to it:
- [ ] If extra release-notes are required, they're listed indented below: