### PR TITLE
Closes #171: Fix Release-Workflow leads to two release-attempts

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,7 +90,37 @@ jobs:
         run: ci/change_version.sh -m .
       - name: Release artifacts to Sonatype-Central
         run: |
-          ./mvnw -B deploy -P $([[ "$GITHUB_REF" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+/[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo "release" || echo "snapshot") \
+          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Detected version: '$VERSION'"
+          
+          if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+            echo "CRITICAL ERROR: Version is empty or null!"
+            echo "   Detected version: '$VERSION'"
+            echo "   Expected:"
+            echo "     - Master branch: x.x.x-SNAPSHOT"
+            echo "     - Tag (x.x.x/x.x.x): x.x.x"
+            echo "   Possible causes:"
+            echo "     - Incorrect tag format"
+            echo "     - Missing or invalid <version> in pom.xml"
+            exit 1
+          fi
+          
+          if [[ "$GITHUB_REF" == "refs/heads/master" && "$VERSION" == *-SNAPSHOT ]]; then
+            echo "Deploying as SNAPSHOT"
+            PROFILE="snapshot"
+          elif [[ "$GITHUB_REF" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+/[0-9]+\.[0-9]+\.[0-9]+$ && "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Deploying as RELEASE"
+            PROFILE="release"
+          else
+            echo "NOT ALLOWED: Invalid deployment combination"
+            echo "   GITHUB_REF: $GITHUB_REF"
+            echo "   Version: '$VERSION'"
+            echo "   Expected combinations:"
+            echo "     - Master branch + SNAPSHOT version (x.x.x-SNAPSHOT)"
+            echo "     - Tag (x.x.x/x.x.x) + RELEASE version (x.x.x)"
+            exit 1
+          fi
+          ./mvnw -B deploy -P $PROFILE \
           --settings ci/mvnsettings.xml -DskipTests -Dcheckstyle.skip -Djacoco.skip \
           -pl :kadai-adapter-parent,\
           :kadai-adapter,:kadai-adapter-camunda-system-connector,:kadai-adapter-kadai-connector,\


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: