### PR TITLE
Closes #137 - Remove C7 Java8-Support

### DIFF
--- a/kadai-adapter-camunda-listener/pom.xml
+++ b/kadai-adapter-camunda-listener/pom.xml
@@ -12,10 +12,6 @@
     <version>11.1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <properties>
-    <version.camunda>7.19.0</version.camunda>
-    <java.version>8</java.version>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>org.camunda.bpm</groupId>
@@ -42,24 +38,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>${version.maven.compiler}</version>
-        <configuration>
-          <source>${maven.compiler.source}</source>
-          <target>${maven.compiler.target}</target>
-          <showWarnings>true</showWarnings>
-          <failOnWarning>true</failOnWarning>
-          <compilerArgs>
-            <arg>-Xlint:-serial</arg>
-            <arg>-proc:none</arg>
-            <arg>-Xbootclasspath:${env.JAVA_HOME_8_X64}/jre/lib/rt.jar</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/kadai-adapter-camunda-outbox-rest/pom.xml
+++ b/kadai-adapter-camunda-outbox-rest/pom.xml
@@ -14,9 +14,6 @@
         <version>11.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <properties>
-        <java.version>8</java.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.camunda.spin</groupId>
@@ -45,22 +42,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${version.maven.compiler}</version>
-                <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
-                    <showWarnings>true</showWarnings>
-                    <failOnWarning>true</failOnWarning>
-                    <compilerArgs>
-                        <arg>-Xlint:-serial</arg>
-                        <arg>-proc:none</arg>
-                        <arg>-Xbootclasspath:${env.JAVA_HOME_8_X64}/jre/lib/rt.jar</arg>
-                    </compilerArgs>
-                </configuration>
-            </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>${version.maven-war-plugin}</version>


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below:
  - Removed Java8-Support for `kadai-adapter-camunda-listener` and `kadai-adapter-camunda-outbox-rest`
  - Aligned Camunda7-Version for all modules. Module `kadai-adapter-camunda-listener` was wrongfully using version `7.19`.