### PR TITLE
Closes #190 - Inline `@Value(..)` instead of using a bean of type `Integer` for `batchSize`

### DIFF
--- a/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/config/Camunda8SystemConnectorConfiguration.java
+++ b/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/config/Camunda8SystemConnectorConfiguration.java
@@ -2,7 +2,6 @@ package io.kadai.adapter.systemconnector.camunda.config;
 
 import io.kadai.adapter.util.config.HttpComponentsClientProperties;
 import java.time.Duration;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,11 +22,5 @@ public class Camunda8SystemConnectorConfiguration {
         .readTimeout(Duration.ofMillis(httpComponentsClientProperties.getReadTimeout()))
         .requestFactory(HttpComponentsClientHttpRequestFactory.class)
         .build();
-  }
-
-  @Bean
-  Integer getFromKadaiToAdapterBatchSize(
-      @Value("${kadai.adapter.sync.kadai.batchSize:#{64}}") final Integer batchSize) {
-    return batchSize;
   }
 }

--- a/kadai-adapter-camunda-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/config/CamundaSystemConnectorConfiguration.java
+++ b/kadai-adapter-camunda-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/config/CamundaSystemConnectorConfiguration.java
@@ -69,12 +69,6 @@ public class CamundaSystemConnectorConfiguration {
   }
 
   @Bean
-  Integer getFromKadaiToAdapterBatchSize(
-      @Value("${kadai.adapter.sync.kadai.batchSize:#{64}}") final Integer batchSize) {
-    return batchSize;
-  }
-
-  @Bean
   @DependsOn(value = {"httpHeaderProvider"})
   CamundaTaskRetriever camundaTaskRetriever(
       final HttpHeaderProvider httpHeaderProvider,

--- a/kadai-adapter-kadai-connector/src/main/java/io/kadai/adapter/kadaiconnector/api/impl/KadaiSystemConnectorImpl.java
+++ b/kadai-adapter-kadai-connector/src/main/java/io/kadai/adapter/kadaiconnector/api/impl/KadaiSystemConnectorImpl.java
@@ -18,7 +18,6 @@
 
 package io.kadai.adapter.kadaiconnector.api.impl;
 
-import io.kadai.adapter.configuration.AdapterSpringContextProvider;
 import io.kadai.adapter.exceptions.TaskCreationFailedException;
 import io.kadai.adapter.exceptions.TaskTerminationFailedException;
 import io.kadai.adapter.kadaiconnector.api.KadaiConnector;
@@ -41,6 +40,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /** Implements KadaiConnector. */
@@ -55,14 +55,16 @@ public class KadaiSystemConnectorImpl implements KadaiConnector {
 
   private final TaskService taskService;
   private final TaskInformationMapper taskInformationMapper;
+  private final Integer batchSize;
 
   public KadaiSystemConnectorImpl(
-      TaskService taskService, TaskInformationMapper taskInformationMapper) {
+      TaskService taskService,
+      TaskInformationMapper taskInformationMapper,
+      @Value("${kadai.adapter.sync.kadai.batchSize:#{64}}") Integer batchSize) {
     this.taskService = taskService;
     this.taskInformationMapper = taskInformationMapper;
+    this.batchSize = batchSize;
   }
-
-  Integer batchSize = AdapterSpringContextProvider.getBean(Integer.class);
 
   public List<ReferencedTask> retrieveFinishedKadaiTasksAsReferencedTasks() {
 


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below:
  - Removed bean `Integer getFromKadaiToAdapterBatchSize`. The value is accessible by injecting `@Value("${kadai.adapter.sync.kadai.batchSize:#{64}}") Integer batchSize`.