### PR TITLE
Closes #191 - Resolve catch log-throw anti-pattern

### DIFF
--- a/kadai-adapter-camunda-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/CamundaTaskClaimCanceler.java
+++ b/kadai-adapter-camunda-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/CamundaTaskClaimCanceler.java
@@ -29,7 +29,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -43,18 +43,19 @@ public class CamundaTaskClaimCanceler {
   private final HttpHeaderProvider httpHeaderProvider;
   private final RestClient restClient;
 
-  public CamundaTaskClaimCanceler(HttpHeaderProvider httpHeaderProvider, RestClient restClient) {
-    this.httpHeaderProvider = httpHeaderProvider;
-    this.restClient = restClient;
-  }
-
   @Value("${kadai.adapter.camunda.claiming.enabled:false}")
   private boolean claimingEnabled;
 
   private boolean cancelClaimConfigLogged = false;
 
+  public CamundaTaskClaimCanceler(HttpHeaderProvider httpHeaderProvider, RestClient restClient) {
+    this.httpHeaderProvider = httpHeaderProvider;
+    this.restClient = restClient;
+  }
+
   public SystemResponse cancelClaimOfCamundaTask(
-      CamundaSystemUrls.SystemUrlInfo camundaSystemUrlInfo, ReferencedTask referencedTask) {
+      CamundaSystemUrls.SystemUrlInfo camundaSystemUrlInfo, ReferencedTask referencedTask)
+      throws HttpStatusCodeException {
 
     if (!cancelClaimConfigLogged) {
       LOGGER.info(
@@ -94,12 +95,6 @@ public class CamundaTaskClaimCanceler {
             httpHeaderProvider, restClient, camundaSystemUrlInfo, referencedTask.getId())) {
           return new SystemResponse(HttpStatus.OK, null);
         }
-        LOGGER.warn(
-            "HTTP client error while cancel claiming Camunda task: {}", e.getStatusCode(), e);
-        throw e;
-      } catch (HttpServerErrorException e) {
-        LOGGER.error(
-            "HTTP server error while cancel claiming Camunda task: {}", e.getStatusCode(), e);
         throw e;
       }
     }

--- a/kadai-adapter-camunda-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/CamundaTaskCompleter.java
+++ b/kadai-adapter-camunda-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/CamundaTaskCompleter.java
@@ -29,6 +29,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClient;
 
 /** Completes Camunda Tasks via the Camunda REST Api. */
@@ -46,7 +47,8 @@ public class CamundaTaskCompleter {
   }
 
   public SystemResponse completeCamundaTask(
-      CamundaSystemUrls.SystemUrlInfo camundaSystemUrlInfo, ReferencedTask referencedTask) {
+      CamundaSystemUrls.SystemUrlInfo camundaSystemUrlInfo, ReferencedTask referencedTask)
+      throws HttpStatusCodeException {
 
     StringBuilder requestUrlBuilder = new StringBuilder();
     try {
@@ -61,10 +63,6 @@ public class CamundaTaskCompleter {
           httpHeaderProvider, restClient, camundaSystemUrlInfo, referencedTask.getId())) {
         return new SystemResponse(HttpStatus.OK, null);
       }
-      LOGGER.warn("Client error while completing Camunda task: {}", e.getStatusCode(), e);
-      throw e;
-    } catch (HttpServerErrorException e) {
-      LOGGER.error("Server error while completing Camunda task: {}", e.getStatusCode(), e);
       throw e;
     }
   }

--- a/kadai-adapter-camunda-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/CamundaTaskEventCleaner.java
+++ b/kadai-adapter-camunda-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/CamundaTaskEventCleaner.java
@@ -24,8 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -44,7 +43,8 @@ public class CamundaTaskEventCleaner {
   }
 
   public void cleanEventsForReferencedTasks(
-      List<ReferencedTask> referencedTasks, String camundaSystemTaskEventUrl) {
+      List<ReferencedTask> referencedTasks, String camundaSystemTaskEventUrl)
+      throws HttpStatusCodeException {
 
     LOGGER.debug(
         "entry to cleanEventsForReferencedTasks, CamundaSystemURL = {}", camundaSystemTaskEventUrl);
@@ -68,25 +68,16 @@ public class CamundaTaskEventCleaner {
   }
 
   private void deleteCamundaTaskEventsFromOutbox(
-      String requestUrl, String idsOfCamundaTaskEventsToDeleteFromOutbox) {
+      String requestUrl, String idsOfCamundaTaskEventsToDeleteFromOutbox)
+      throws HttpStatusCodeException {
     HttpHeaders headers = httpHeaderProvider.getHttpHeadersForOutboxRestApi();
-    try {
-      restClient
-          .post()
-          .uri(requestUrl)
-          .headers(httpHeaders -> httpHeaders.addAll(headers))
-          .body(idsOfCamundaTaskEventsToDeleteFromOutbox)
-          .retrieve()
-          .toEntity(Void.class);
-    } catch (HttpClientErrorException e) {
-      LOGGER.error(
-          "HTTP client error while deleting Camunda task events: {}", e.getStatusCode(), e);
-      throw e;
-    } catch (HttpServerErrorException e) {
-      LOGGER.error(
-          "HTTP server error while deleting Camunda task events: {}", e.getStatusCode(), e);
-      throw e;
-    }
+    restClient
+        .post()
+        .uri(requestUrl)
+        .headers(httpHeaders -> httpHeaders.addAll(headers))
+        .body(idsOfCamundaTaskEventsToDeleteFromOutbox)
+        .retrieve()
+        .toEntity(Void.class);
   }
 
   private String getIdsOfCamundaTaskEventsToDeleteFromOutbox(List<ReferencedTask> referencedTasks) {

--- a/kadai-adapter-camunda-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/HttpHeaderProvider.java
+++ b/kadai-adapter-camunda-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/HttpHeaderProvider.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HttpHeaderProvider {
 
-  private static String undefined = "undefined";
+  private static final String UNDEFINED = "undefined";
 
   @Value("${kadai-system-connector-camunda-rest-api-user-name:undefined}")
   private String camundaRestApiUserName;
@@ -46,7 +46,7 @@ public class HttpHeaderProvider {
   private String xsrfToken;
 
   public HttpHeaders camundaRestApiHeaders() {
-    if (undefined.equals(camundaRestApiUserName)) {
+    if (UNDEFINED.equals(camundaRestApiUserName)) {
       return new HttpHeaders();
     } else {
       String plainCreds = camundaRestApiUserName + ":" + camundaRestApiUserPassword;
@@ -55,7 +55,7 @@ public class HttpHeaderProvider {
   }
 
   public HttpHeaders outboxRestApiHeaders() {
-    if (undefined.equals(outboxRestApiUserName)) {
+    if (UNDEFINED.equals(outboxRestApiUserName)) {
       return new HttpHeaders();
     } else {
       String plainCreds = outboxRestApiUserName + ":" + outboxRestApiUserPassword;


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below:
  - Fixed a bug where Camunda7 HTTP-Errors would be logged twice