### PR TITLE
Closes #308 - Resolve Camunda 8 configuration mess

### DIFF
--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-example/src/main/resources/application.properties
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-example/src/main/resources/application.properties
@@ -47,17 +47,11 @@ kadai.adapter.mapping.default.objectreference.type=DEFAULT_TYPE
 kadai.adapter.mapping.default.objectreference.value=DEFAULT_VALUE
 management.endpoints.web.exposure.include=*
 management.endpoint.health.show-details=always
-management.health.external-services.enabled=true
 ####################################################################################
 # Camunda 8 properties
 ####################################################################################
+camunda.client.enabled=true
 camunda.client.mode=self-managed
-camunda.client.auth.token-url=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
-camunda.client.zeebe.enabled=true
-camunda.client.zeebe.rest-address=http://localhost:8081
-camunda.client.zeebe.grpc-address=http://localhost:26500
-camunda.client.zeebe.audience=zeebe-api
-kadai.adapter.plugin.camunda8.system-url=http://localhost:26500
-kadai.adapter.plugin.camunda8.cluster-api-url=http://localhost:8081
+camunda.client.rest-address=http://localhost:8081
 #for health-tests
 kadai-system-connector-camundaSystemURLs=http://localhost:8081|http://localhost:8081

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8SystemConnectorImpl.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8SystemConnectorImpl.java
@@ -51,7 +51,7 @@ public class Camunda8SystemConnectorImpl implements OutboundSystemConnector {
 
   @Override
   public String getSystemUrl() {
-    return camunda8System.getSystemUrl();
+    return camunda8System.getRestAddress();
   }
 
   @Override

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskClaimCanceler.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskClaimCanceler.java
@@ -47,7 +47,7 @@ public class Camunda8TaskClaimCanceler {
     if (claimingEnabled) {
       StringBuilder requestUrlBuilder = new StringBuilder();
       requestUrlBuilder
-          .append(camunda8System.getClusterApiUrl())
+          .append(camunda8System.getRestAddress())
           .append(Camunda8SystemConnectorImpl.URL_GET_CAMUNDA8_USER_TASKS)
           .append(getUserTaskKeyFromReferencedTask(referencedTask))
           .append(Camunda8SystemConnectorImpl.URL_CAMUNDA8_UNCLAIM);

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskClaimer.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskClaimer.java
@@ -48,7 +48,7 @@ public class Camunda8TaskClaimer {
     if (claimingEnabled) {
       StringBuilder requestUrlBuilder = new StringBuilder();
       requestUrlBuilder
-          .append(camunda8System.getClusterApiUrl())
+          .append(camunda8System.getRestAddress())
           .append(Camunda8SystemConnectorImpl.URL_GET_CAMUNDA8_USER_TASKS)
           .append(getUserTaskKeyFromReferencedTask(referencedTask))
           .append(Camunda8SystemConnectorImpl.URL_CAMUNDA8_ASSIGNMENT);

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskCompleter.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskCompleter.java
@@ -48,7 +48,7 @@ public class Camunda8TaskCompleter {
     if (completingEnabled) {
       StringBuilder requestUrlBuilder = new StringBuilder();
       requestUrlBuilder
-          .append(camunda8System.getClusterApiUrl())
+          .append(camunda8System.getRestAddress())
           .append(Camunda8SystemConnectorImpl.URL_GET_CAMUNDA8_USER_TASKS)
           .append(getUserTaskKeyFromReferencedTask(referencedTask))
           .append(Camunda8SystemConnectorImpl.URL_CAMUNDA8_COMPLETION);

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8UtilRequester.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8UtilRequester.java
@@ -24,7 +24,7 @@ public class Camunda8UtilRequester {
       String userTaskKey) {
 
     String requestUrl =
-        camunda8System.getClusterApiUrl()
+        camunda8System.getRestAddress()
             + Camunda8SystemConnectorImpl.URL_GET_CAMUNDA8_USER_TASKS
             + userTaskKey;
 

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/config/Camunda8System.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/config/Camunda8System.java
@@ -1,9 +1,9 @@
 package io.kadai.adapter.systemconnector.camunda.config;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 
-@Configuration
+@Component
 public class Camunda8System {
 
   @Value("${camunda.client.rest-address}")

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/config/Camunda8System.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/config/Camunda8System.java
@@ -1,29 +1,20 @@
 package io.kadai.adapter.systemconnector.camunda.config;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConfigurationProperties(prefix = "kadai.adapter.plugin.camunda8")
 public class Camunda8System {
 
-  private String systemUrl;
-  private String clusterApiUrl;
+  @Value("${camunda.client.rest-address}")
+  private String restAddress;
 
-  public String getSystemUrl() {
-    return systemUrl;
+  public String getRestAddress() {
+    return restAddress;
   }
 
-  public void setSystemUrl(String systemUrl) {
-    this.systemUrl = systemUrl;
-  }
-
-  public String getClusterApiUrl() {
-    return clusterApiUrl;
-  }
-
-  public void setClusterApiUrl(String clusterApiUrl) {
-    this.clusterApiUrl = clusterApiUrl;
+  public void setRestAddress(String restAddress) {
+    this.restAddress = restAddress;
   }
 
   // Hard-coded now until multiple C8-Systems are supported, configured OR derived then

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/tasklistener/util/ReferencedTaskCreator.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/main/java/io/kadai/adapter/systemconnector/camunda/tasklistener/util/ReferencedTaskCreator.java
@@ -69,7 +69,7 @@ public class ReferencedTaskCreator {
     referencedTask.setCustomInt8(getVariable(job, "kadai_custom_int_8"));
 
     referencedTask.setVariables(getKadaiProcessVariables(job));
-    referencedTask.setSystemUrl(camunda8System.getSystemUrl());
+    referencedTask.setSystemUrl(camunda8System.getRestAddress());
 
     LOGGER.debug("Creating ReferencedTask from job: {}", referencedTask);
 

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/Camunda8TestSetupListener.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/Camunda8TestSetupListener.java
@@ -18,7 +18,7 @@ public class Camunda8TestSetupListener implements TestExecutionListener {
         testContext.getApplicationContext().getBean(Camunda8System.class);
 
     if (client.getConfiguration().getRestAddress() != null) {
-      camunda8System.setClusterApiUrl(client.getConfiguration().getRestAddress().toString());
+      camunda8System.setRestAddress(client.getConfiguration().getRestAddress().toString());
     }
   }
 }

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/Camunda8TestSetupListener.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/Camunda8TestSetupListener.java
@@ -2,39 +2,40 @@ package io.kadai.adapter.systemconnector.camunda;
 
 import io.camunda.client.CamundaClient;
 import io.kadai.adapter.manager.AdapterManager;
-import io.kadai.adapter.systemconnector.api.OutboundSystemConnector;
+import io.kadai.adapter.systemconnector.camunda.api.impl.Camunda8SystemConnectorImpl;
+import io.kadai.adapter.systemconnector.camunda.api.impl.Camunda8TaskClaimCanceler;
+import io.kadai.adapter.systemconnector.camunda.api.impl.Camunda8TaskClaimer;
+import io.kadai.adapter.systemconnector.camunda.api.impl.Camunda8TaskCompleter;
 import io.kadai.adapter.systemconnector.camunda.config.Camunda8System;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 
 public class Camunda8TestSetupListener implements TestExecutionListener {
 
-  private static final String CAMUNDA_8_SELF_MANAGED_DEFAULT_REST_ADDRESS = "http://localhost:8088";
-
   @Override
   public void beforeTestMethod(TestContext testContext) {
     CamundaClient client = testContext.getApplicationContext().getBean(CamundaClient.class);
     Camunda8System camunda8System =
         testContext.getApplicationContext().getBean(Camunda8System.class);
-    AdapterManager adapterManager =
-        testContext.getApplicationContext().getBean(AdapterManager.class);
 
     final String camunda8RestAddress = client.getConfiguration().getRestAddress().toString();
     camunda8System.setRestAddress(camunda8RestAddress);
 
-    // When AdapterManager loads C8 SPI, the rest-address is not yet set for tests because
-    // the CamundaClient is not yet initialized.
-    // Therefore, Camunda itself defaults to CAMUNDA_8_SELF_MANAGED_DEFAULT_REST_ADDRESS.
-    // Hence, why we need to overwrite it here with the actual address (due to dynamic port).
-    final OutboundSystemConnector camunda8OutboundSystemConnector =
-        adapterManager
-            .getOutboundSystemConnectors()
-            .remove(CAMUNDA_8_SELF_MANAGED_DEFAULT_REST_ADDRESS);
+    // Each test-suite gets its own Camunda8-Instance
+    // Hence, why we keep adding these new instances
+    // While this technically leads to "old" OutBoundSystemConnectors it's irrelevant
+    // because we look up by key (system-url) anyway
+    AdapterManager adapterManager =
+        testContext.getApplicationContext().getBean(AdapterManager.class);
+    final Camunda8SystemConnectorImpl camunda8SystemConnectorImpl =
+        new Camunda8SystemConnectorImpl(
+            testContext.getApplicationContext().getBean(Camunda8System.class),
+            testContext.getApplicationContext().getBean(Camunda8TaskClaimer.class),
+            testContext.getApplicationContext().getBean(Camunda8TaskCompleter.class),
+            testContext.getApplicationContext().getBean(Camunda8TaskClaimCanceler.class));
 
-    if (camunda8OutboundSystemConnector != null) {
-      adapterManager
-          .getOutboundSystemConnectors()
-          .put(camunda8RestAddress, camunda8OutboundSystemConnector);
-    }
+    adapterManager
+        .getOutboundSystemConnectors()
+        .put(camunda8RestAddress, camunda8SystemConnectorImpl);
   }
 }

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/Camunda8TestSetupListener.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/Camunda8TestSetupListener.java
@@ -1,24 +1,40 @@
 package io.kadai.adapter.systemconnector.camunda;
 
 import io.camunda.client.CamundaClient;
+import io.kadai.adapter.manager.AdapterManager;
+import io.kadai.adapter.systemconnector.api.OutboundSystemConnector;
 import io.kadai.adapter.systemconnector.camunda.config.Camunda8System;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 
-/**
- * TestExecutionListener that sets Camunda8System.clusterApiUrl from the CamundaClient before each
- * test. Temporary workaround to camunda/camunda#40223
- */
 public class Camunda8TestSetupListener implements TestExecutionListener {
+
+  private static final String CAMUNDA_8_SELF_MANAGED_DEFAULT_REST_ADDRESS = "http://localhost:8088";
 
   @Override
   public void beforeTestMethod(TestContext testContext) {
     CamundaClient client = testContext.getApplicationContext().getBean(CamundaClient.class);
     Camunda8System camunda8System =
         testContext.getApplicationContext().getBean(Camunda8System.class);
+    AdapterManager adapterManager =
+        testContext.getApplicationContext().getBean(AdapterManager.class);
 
-    if (client.getConfiguration().getRestAddress() != null) {
-      camunda8System.setRestAddress(client.getConfiguration().getRestAddress().toString());
+    final String camunda8RestAddress = client.getConfiguration().getRestAddress().toString();
+    camunda8System.setRestAddress(camunda8RestAddress);
+
+    // When AdapterManager loads C8 SPI, the rest-address is not yet set for tests because
+    // the CamundaClient is not yet initialized.
+    // Therefore, Camunda itself defaults to CAMUNDA_8_SELF_MANAGED_DEFAULT_REST_ADDRESS.
+    // Hence, why we need to overwrite it here with the actual address (due to dynamic port).
+    final OutboundSystemConnector camunda8OutboundSystemConnector =
+        adapterManager
+            .getOutboundSystemConnectors()
+            .remove(CAMUNDA_8_SELF_MANAGED_DEFAULT_REST_ADDRESS);
+
+    if (camunda8OutboundSystemConnector != null) {
+      adapterManager
+          .getOutboundSystemConnectors()
+          .put(camunda8RestAddress, camunda8OutboundSystemConnector);
     }
   }
 }

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskCompleterTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskCompleterTest.java
@@ -60,6 +60,7 @@ class Camunda8TaskCompleterTest {
     final Task completedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
     assertThat(completedKadaiTask.getState()).isEqualTo(TaskState.COMPLETED);
     String externalId = kadaiTask.getExternalId();
+
     long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
     camunda8TestUtil.waitUntil(
         () -> "COMPLETED".equals(camunda8TestUtil.getCamundaTaskStatus(camundaTaskKey)));

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/camunda8-test-application.properties
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/camunda8-test-application.properties
@@ -3,7 +3,7 @@
 ####################################################################################
 camunda.client.mode=self-managed
 camunda.client.enabled=true
-camunda.client.rest-address=http://localhost:8088
+
 # Appeasing placeholder...
 kadai-system-connector-camundaSystemURLs=http://localhost:${server.port}/engine-rest/engine/default | http://localhost:${server.port}/
 kadai.adapter.scheduler.run.interval.for.claim.referenced.tasks.in.milliseconds=1000

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/camunda8-test-application.properties
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/camunda8-test-application.properties
@@ -2,12 +2,8 @@
 # Camunda 8 properties
 ####################################################################################
 camunda.client.mode=self-managed
-camunda.client.auth.token-url=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
-camunda.client.zeebe.enabled=true
-#camunda.client.zeebe.rest-address=http://localhost:8088
-camunda.client.zeebe.grpc-address=http://localhost:26500
-camunda.client.zeebe.audience=zeebe-api
-kadai.adapter.plugin.camunda8.system-url=http://localhost:26500
+camunda.client.enabled=true
+camunda.client.rest-address=http://localhost:8088
 # Appeasing placeholder...
 kadai-system-connector-camundaSystemURLs=http://localhost:${server.port}/engine-rest/engine/default | http://localhost:${server.port}/
 kadai.adapter.scheduler.run.interval.for.claim.referenced.tasks.in.milliseconds=1000

--- a/kadai-adapter/src/main/java/io/kadai/adapter/impl/scheduled/ReferencedTaskCompleter.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/impl/scheduled/ReferencedTaskCompleter.java
@@ -128,7 +128,7 @@ public class ReferencedTaskCompleter implements MonitoredScheduledComponent {
         success = true;
       } else {
         throw new SystemException(
-            "couldnt find a connector for systemUrl " + referencedTask.getSystemUrl());
+            "couldn't find a connector for systemUrl " + referencedTask.getSystemUrl());
       }
     } catch (Exception ex) {
       LOGGER.error(


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [ ] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it: https://github.com/kadai-io/kadai-doc/pull/150
- [x] If extra release-notes are required, they're listed indented below:
  - Removed properties `kadai.adapter.plugin.camunda8.system-url` and `kadai.adapter.plugin.camunda8.cluster-api-url` as we now infer required URLs from the `CamundaClient` (configured via `camunda.client.rest-address`)