### PR TITLE
Closes #351 - Kernel to consequently log catch-all exceptions as errors

### DIFF
--- a/kadai-adapter/src/main/java/io/kadai/adapter/impl/scheduled/KadaiTaskCompletionOrchestrator.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/impl/scheduled/KadaiTaskCompletionOrchestrator.java
@@ -91,7 +91,7 @@ public class KadaiTaskCompletionOrchestrator implements MonitoredScheduledCompon
         monitoredRun.succeed();
       } catch (Exception e) {
         monitoredRun.fail();
-        LOGGER.warn(
+        LOGGER.error(
             "caught exception while trying to retrieve "
                 + "finished referenced tasks and terminate corresponding kadai tasks",
             e);
@@ -121,7 +121,7 @@ public class KadaiTaskCompletionOrchestrator implements MonitoredScheduledCompon
               ex);
           systemConnector.unlockEvent(referencedTask.getOutboxEventId());
         } catch (Exception e) {
-          LOGGER.warn(
+          LOGGER.error(
               "caught unexpected Exception when attempting to terminate KadaiTask "
                   + "for referencedTask {}",
               referencedTask,

--- a/kadai-adapter/src/main/java/io/kadai/adapter/impl/scheduled/KadaiTaskStarterOrchestrator.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/impl/scheduled/KadaiTaskStarterOrchestrator.java
@@ -158,7 +158,7 @@ public class KadaiTaskStarterOrchestrator implements MonitoredScheduledComponent
       ReferencedTask referencedTask,
       Exception exception,
       String message) {
-    LOGGER.warn(message, referencedTask, exception);
+    LOGGER.error(message, referencedTask, exception);
     systemConnector.kadaiTaskFailedToBeCreatedForNewReferencedTask(referencedTask, exception);
     systemConnector.unlockEvent(referencedTask.getOutboxEventId());
   }

--- a/kadai-adapter/src/main/java/io/kadai/adapter/impl/scheduled/ReferencedTaskClaimCanceler.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/impl/scheduled/ReferencedTaskClaimCanceler.java
@@ -86,7 +86,7 @@ public class ReferencedTaskClaimCanceler implements MonitoredScheduledComponent 
         monitoredRun.succeed();
       } catch (Exception ex) {
         monitoredRun.fail();
-        LOGGER.debug("Caught exception while trying to cancel claim referenced tasks", ex);
+        LOGGER.error("Caught exception while trying to cancel claim referenced tasks", ex);
       } finally {
         runDurationLowerMedian.add(monitoredRun.getDuration());
       }

--- a/kadai-adapter/src/main/java/io/kadai/adapter/impl/scheduled/ReferencedTaskClaimer.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/impl/scheduled/ReferencedTaskClaimer.java
@@ -84,7 +84,7 @@ public class ReferencedTaskClaimer implements MonitoredScheduledComponent {
         monitoredRun.succeed();
       } catch (Exception ex) {
         monitoredRun.fail();
-        LOGGER.debug("Caught exception while trying to claim referenced tasks", ex);
+        LOGGER.error("Caught exception while trying to claim referenced tasks", ex);
       } finally {
         runDurationLowerMedian.add(monitoredRun.getDuration());
       }

--- a/kadai-adapter/src/main/java/io/kadai/adapter/impl/scheduled/ReferencedTaskCompleter.java
+++ b/kadai-adapter/src/main/java/io/kadai/adapter/impl/scheduled/ReferencedTaskCompleter.java
@@ -87,7 +87,7 @@ public class ReferencedTaskCompleter implements MonitoredScheduledComponent {
         monitoredRun.succeed();
       } catch (Exception ex) {
         monitoredRun.fail();
-        LOGGER.debug("Caught exception while trying to complete referenced tasks", ex);
+        LOGGER.error("Caught exception while trying to complete referenced tasks", ex);
       } finally {
         runDurationLowerMedian.add(monitoredRun.getDuration());
       }


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: