### PR TITLE
Closes #376 - Swap Class-bound Outbox-Datasource for lazy static variant

### DIFF
--- a/kadai-adapter-camunda-outbox-rest/src/main/java/io/kadai/adapter/camunda/outbox/rest/config/OutboxDataSource.java
+++ b/kadai-adapter-camunda-outbox-rest/src/main/java/io/kadai/adapter/camunda/outbox/rest/config/OutboxDataSource.java
@@ -13,6 +13,8 @@ public final class OutboxDataSource {
   private static final Logger LOGGER = LoggerFactory.getLogger(OutboxDataSource.class);
   private static volatile DataSource dataSource;
 
+  private OutboxDataSource() {}
+
   public static DataSource get() {
     DataSource local = dataSource;
     if (local == null) {

--- a/kadai-adapter-camunda-outbox-rest/src/main/java/io/kadai/adapter/camunda/outbox/rest/config/OutboxDataSource.java
+++ b/kadai-adapter-camunda-outbox-rest/src/main/java/io/kadai/adapter/camunda/outbox/rest/config/OutboxDataSource.java
@@ -1,0 +1,46 @@
+package io.kadai.adapter.camunda.outbox.rest.config;
+
+import io.kadai.adapter.camunda.OutboxRestConfiguration;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+import org.apache.ibatis.datasource.pooled.PooledDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class OutboxDataSource {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OutboxDataSource.class);
+  private static volatile DataSource dataSource;
+
+  public static DataSource get() {
+    DataSource local = dataSource;
+    if (local == null) {
+      synchronized (OutboxDataSource.class) {
+        local = dataSource;
+        if (local == null) {
+          dataSource = local = getDataSourceFromPropertiesFile();
+        }
+      }
+    }
+    return local;
+  }
+
+  private static DataSource getDataSourceFromPropertiesFile() {
+    String jndiUrl = OutboxRestConfiguration.getOutboxDatasourceJndi();
+    if (jndiUrl != null) {
+      try {
+        return (DataSource) new InitialContext().lookup(jndiUrl);
+      } catch (NamingException e) {
+        LOGGER.error("Failed creating initial context. Rethrowing as RuntimeException.", e);
+        throw new RuntimeException(e);
+      }
+    } else {
+      return new PooledDataSource(
+          OutboxRestConfiguration.getOutboxDatasourceDriver(),
+          OutboxRestConfiguration.getOutboxDatasourceUrl(),
+          OutboxRestConfiguration.getOutboxDatasourceUsername(),
+          OutboxRestConfiguration.getOutboxDatasourcePassword());
+    }
+  }
+}


### PR DESCRIPTION
The data-source for the C7 Outbox is now lazily initialized in a separate Singleton-Class.
This prevents multiple connection-pools from being created.

<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [ ] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: