### PR TITLE
Closes #248 - Support Camunda 8 multi-tenancy

### DIFF
--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-multi-tenancy-example/pom.xml
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-multi-tenancy-example/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>kadai-adapter-camunda-8-spring-boot-multi-tenancy-example</artifactId>
+  <packaging>jar</packaging>
+
+  <name>${project.groupId}:${project.artifactId}</name>
+  <url>http://maven.apache.org</url>
+
+  <parent>
+    <groupId>io.kadai</groupId>
+    <artifactId>kadai-adapter-camunda8-parent</artifactId>
+    <version>11.2.1-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.kadai</groupId>
+      <artifactId>kadai-adapter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.kadai</groupId>
+      <artifactId>kadai-adapter-camunda-8-system-connector</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.kadai</groupId>
+      <artifactId>kadai-adapter-kadai-connector</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.db2</groupId>
+      <artifactId>jcc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring.boot}</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-multi-tenancy-example/src/main/java/io/kadai/adapter/KadaiAdapterApplicationC8.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-multi-tenancy-example/src/main/java/io/kadai/adapter/KadaiAdapterApplicationC8.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright [2024] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package io.kadai.adapter;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/** Application that provides an adapter between KADAI and one or more external systems. */
+@SpringBootApplication
+@EnableScheduling
+@EnableTransactionManagement
+public class KadaiAdapterApplicationC8 {
+
+  public static void main(String[] args) {
+    SpringApplication.run(KadaiAdapterApplicationC8.class, args);
+  }
+}

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-multi-tenancy-example/src/main/java/io/kadai/taskrouting/ExampleTaskRouter.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-multi-tenancy-example/src/main/java/io/kadai/taskrouting/ExampleTaskRouter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright [2024] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package io.kadai.taskrouting;
+
+import io.kadai.common.api.KadaiEngine;
+import io.kadai.spi.routing.api.TaskRoutingProvider;
+import io.kadai.task.api.models.Task;
+
+/** This is a sample implementation of TaskRouter. */
+public class ExampleTaskRouter implements TaskRoutingProvider {
+
+  @Override
+  public void initialize(KadaiEngine kadaiEngine) {
+    // no-op
+  }
+
+  @Override
+  public String determineWorkbasketId(Task task) {
+    return "WBI:100000000000000000000000000000000001";
+  }
+}

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-multi-tenancy-example/src/main/resources/application.properties
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-multi-tenancy-example/src/main/resources/application.properties
@@ -1,0 +1,61 @@
+######################################################################################
+## Adapter properties
+######################################################################################
+##
+#logging.level.org.springframework=DEBUG
+logging.level.io.kadai=WARN
+#logging.level.com.spring.ibatis=DEBUG
+#logging.level.com.spring.ibatis.*=DEBUG
+#logging.level.org.apache.ibatis=DEBUG
+#logging.level.io.kadai=info
+## Set Server Port for Adapter
+server.port=18082
+spring.main.allow-bean-definition-overriding=true
+kadai.adapter.run-as.user=taskadmin
+kadai.adapter.scheduler.run.interval.for.start.kadai.tasks.in.milliseconds=10000
+kadai.adapter.scheduler.run.interval.for.complete.referenced.tasks.in.milliseconds=10000
+kadai.adapter.scheduler.run.interval.for.claim.referenced.tasks.in.milliseconds=10000
+kadai.adapter.scheduler.run.interval.for.cancel.claim.referenced.tasks.in.milliseconds=10000
+kadai.adapter.scheduler.run.interval.for.check.finished.referenced.tasks.in.milliseconds=10000
+####################################################################################
+# Kadai-connector properties
+####################################################################################
+#
+# Configure the datasource for Kadai DB (used by kadai-connector)
+#kadai.datasource.jdbcUrl = jdbc:h2:tcp://localhost:9095/mem:kadai;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;
+#kadai.datasource.jdbcUrl=jdbc:h2:mem:kadai;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE
+#kadai.datasource.driverClassName=org.h2.Driver
+#kadai.datasource.username=sa
+#kadai.datasource.password=sa
+#kadai.schemaName=KADAI
+kadai.adapter.events.lockDuration=300
+kadai.adapter.sync.kadai.batchSize=1
+#
+# kadai.datasource.jdbcUrl=jdbc:db2://localhost:50050/kadai
+# kadai.datasource.driverClassName=com.ibm.db2.jcc.DB2Driver
+# kadai.datasource.username=db2user
+# kadai.datasource.password=Db2password
+kadai.datasource.jdbcUrl=jdbc:postgresql://localhost:5432/postgres
+kadai.datasource.driverClassName=org.postgresql.Driver
+kadai.datasource.username=postgres
+kadai.datasource.password=postgres
+kadai.schemaName=kadai
+kadai.adapter.mapping.default.objectreference.company=DEFAULT_COMPANY
+kadai.adapter.mapping.default.objectreference.system=DEFAULT_SYSTEM
+kadai.adapter.mapping.default.objectreference.system.instance=DEFAULT_SYSTEM_INSTANCE
+kadai.adapter.mapping.default.objectreference.type=DEFAULT_TYPE
+kadai.adapter.mapping.default.objectreference.value=DEFAULT_VALUE
+management.endpoints.web.exposure.include=*
+management.endpoint.health.show-details=always
+####################################################################################
+# Camunda 8 properties
+####################################################################################
+camunda.client.enabled=true
+camunda.client.mode=self-managed
+camunda.client.rest-address=http://localhost:8081
+# camunda client authentication
+camunda.client.auth.username=demo
+camunda.client.auth.password=demo
+camunda.client.worker.defaults.tenant-ids=<default>,tenant1,tenant2
+#for health-tests
+kadai-system-connector-camundaSystemURLs=http://localhost:8081|http://localhost:8081

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-multi-tenancy-example/src/main/resources/kadai.properties
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-multi-tenancy-example/src/main/resources/kadai.properties
@@ -1,0 +1,11 @@
+kadai.roles.user=group1 | group2|teamlead-1 |teamlead-2 |user-1-1| user-1-1| user-1-2| user-2-1| user-2-2| max|elena|simone
+kadai.roles.Admin=name=konrad,Organisation=envite|admin
+kadai.roles.business_admin=max|Moritz|businessadmin
+kadai.roles.task_admin=peter | taskadmin
+kadai.roles.monitor=john|teamlead_2 | monitor
+kadai.domains=DOMAIN_A|DOMAIN_B|DOMAIN_C
+kadai.classification.types=TASK|DOCUMENT
+kadai.classification.categories.task=EXTERNAL| manual| autoMAtic| Process
+kadai.classification.categories.document=EXTERNAL
+kadai.jobs.enabled=false
+

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskClaimerTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskClaimerTest.java
@@ -284,6 +284,7 @@ class Camunda8TaskClaimerTest {
       client
           .newDeployResourceCommand()
           .addResourceFromClasspath("processes/sayHello.bpmn")
+          .tenantId(tenant1)
           .send()
           .join();
 
@@ -292,6 +293,7 @@ class Camunda8TaskClaimerTest {
               .newCreateInstanceCommand()
               .bpmnProcessId("Test_Process")
               .latestVersion()
+              .tenantId(tenant1)
               .send()
               .join();
 

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskClaimerTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskClaimerTest.java
@@ -13,188 +13,426 @@ import io.kadai.common.test.security.WithAccessId;
 import io.kadai.task.api.models.Task;
 import io.kadai.task.api.models.TaskSummary;
 import java.util.List;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * Tests for claiming tasks from Kadai to Camunda 8. Tests the synchronisation of assignees when
  * tasks get claimed in Kadai.
  */
-@KadaiAdapterCamunda8SpringBootTest
+@DirtiesContext
 class Camunda8TaskClaimerTest {
 
-  @Autowired Camunda8TestUtil camunda8TestUtil;
-  @Autowired private CamundaClient client;
-  @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
-  @Autowired private KadaiEngine kadaiEngine;
+  @Nested
+  @KadaiAdapterCamunda8SpringBootTest
+  class NoMultiTenancyCamunda8TaskClaimerTest {
 
-  @Test
-  @WithAccessId(user = "admin")
-  void should_ClaimCamundaTask_When_KadaiTaskIsClaimed() throws Exception {
-    kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
-    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
+    @Autowired Camunda8TestUtil camunda8TestUtil;
+    @Autowired private CamundaClient client;
+    @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
+    @Autowired private KadaiEngine kadaiEngine;
 
-    final ProcessInstanceEvent processInstance =
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId("Test_Process")
-            .latestVersion()
-            .send()
-            .join();
+    @Test
+    @WithAccessId(user = "admin")
+    void should_ClaimCamundaTask_When_KadaiTaskIsClaimed() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .send()
+          .join();
 
-    CamundaAssert.assertThat(processInstance).isActive();
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .send()
+              .join();
 
-    final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
-    assertThat(tasks).hasSize(1);
+      CamundaAssert.assertThat(processInstance).isActive();
 
-    final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
+      final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(tasks).hasSize(1);
 
-    kadaiEngine.getTaskService().claim(kadaiTask.getId());
+      final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
 
-    final Task claimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
-    assertThat(claimedKadaiTask.getOwner()).isEqualTo("admin");
-    assertThat(claimedKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.CLAIMED);
-    String externalId = kadaiTask.getExternalId();
-    long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
-    camunda8TestUtil.waitUntil(
-        () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+      kadaiEngine.getTaskService().claim(kadaiTask.getId());
+
+      final Task claimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(claimedKadaiTask.getOwner()).isEqualTo("admin");
+      assertThat(claimedKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.CLAIMED);
+      String externalId = kadaiTask.getExternalId();
+      long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
+      camunda8TestUtil.waitUntil(
+          () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+    }
+
+    @Test
+    @WithAccessId(user = "admin")
+    void should_ClaimAlreadyClaimedCamundaTask_When_ClaimKadaiTask() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .send()
+          .join();
+
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .send()
+              .join();
+
+      CamundaAssert.assertThat(processInstance).isActive();
+
+      final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(tasks).hasSize(1);
+
+      final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
+      String externalId = kadaiTask.getExternalId();
+      long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
+
+      camunda8TestUtil.assignCamundaTask(camundaTaskKey, "user-1-1");
+      camunda8TestUtil.waitUntil(
+          () -> "user-1-1".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+
+      assertThat(kadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.READY);
+      kadaiEngine.getTaskService().claim(kadaiTask.getId());
+
+      final Task claimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(claimedKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.CLAIMED);
+      assertThat(claimedKadaiTask.getOwner()).isEqualTo("admin");
+
+      camunda8TestUtil.waitUntil(
+          () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+    }
+
+    @Test
+    @WithAccessId(user = "admin")
+    void should_CancelClaimCamundaTask_When_KadaiTaskIsCancelClaimed() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .send()
+          .join();
+
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .send()
+              .join();
+
+      CamundaAssert.assertThat(processInstance).isActive();
+
+      final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(tasks).hasSize(1);
+
+      final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
+
+      kadaiEngine.getTaskService().claim(kadaiTask.getId());
+
+      final Task claimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(claimedKadaiTask.getOwner()).isEqualTo("admin");
+      assertThat(claimedKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.CLAIMED);
+
+      String externalId = kadaiTask.getExternalId();
+      long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
+      camunda8TestUtil.waitUntil(
+          () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+
+      kadaiEngine.getTaskService().cancelClaim(kadaiTask.getId());
+      Task cancelClaimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(cancelClaimedKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.READY);
+      camunda8TestUtil.waitUntil(
+          () -> camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey) == null);
+    }
+
+    @Test
+    @WithAccessId(user = "admin")
+    void should_ClaimCamundaTaskAgain_When_ClaimKadaiTaskAfterCancelClaim() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .send()
+          .join();
+
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .send()
+              .join();
+
+      CamundaAssert.assertThat(processInstance).isActive();
+
+      final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(tasks).hasSize(1);
+
+      final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
+      String externalId = kadaiTask.getExternalId();
+      long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
+
+      kadaiEngine.getTaskService().claim(kadaiTask.getId());
+      camunda8TestUtil.waitUntil(
+          () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+
+      kadaiEngine.getTaskService().cancelClaim(kadaiTask.getId());
+      camunda8TestUtil.waitUntil(
+          () -> camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey) == null);
+
+      kadaiEngine.getTaskService().claim(kadaiTask.getId());
+      Task finalKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(finalKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.CLAIMED);
+
+      camunda8TestUtil.waitUntil(
+          () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+    }
   }
 
-  @Test
-  @WithAccessId(user = "admin")
-  void should_ClaimAlreadyClaimedCamundaTask_When_ClaimKadaiTask() throws Exception {
-    kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
-    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+  @Nested
+  @TestPropertySource("classpath:camunda8-mt-test-application.properties")
+  @KadaiAdapterCamunda8SpringBootTest
+  class MultiTenancyCamunda8TaskClaimerTest {
+    @Autowired Camunda8TestUtil camunda8TestUtil;
+    @Autowired private CamundaClient client;
+    @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
+    @Autowired private KadaiEngine kadaiEngine;
 
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
+    @Test
+    @WithAccessId(user = "admin")
+    void should_ClaimCamundaTask_When_KadaiTaskIsClaimed() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
 
-    final ProcessInstanceEvent processInstance =
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId("Test_Process")
-            .latestVersion()
-            .send()
-            .join();
+      // create new Tenant and add user to it (user needs access to all tenants)
+      final String tenant1 = "tenant1";
+      final String allTenantsUser = "demo";
+      client.newCreateTenantCommand().tenantId(tenant1).name(tenant1).send().join();
+      client
+          .newAssignUserToTenantCommand()
+          .username(allTenantsUser)
+          .tenantId(tenant1)
+          .send()
+          .join();
 
-    CamundaAssert.assertThat(processInstance).isActive();
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .send()
+          .join();
 
-    final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
-    assertThat(tasks).hasSize(1);
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .send()
+              .join();
 
-    final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
-    String externalId = kadaiTask.getExternalId();
-    long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
+      CamundaAssert.assertThat(processInstance).isActive();
 
-    camunda8TestUtil.assignCamundaTask(camundaTaskKey, "user-1-1");
-    camunda8TestUtil.waitUntil(
-        () -> "user-1-1".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+      final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(tasks).hasSize(1);
 
-    assertThat(kadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.READY);
-    kadaiEngine.getTaskService().claim(kadaiTask.getId());
+      final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
 
-    final Task claimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
-    assertThat(claimedKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.CLAIMED);
-    assertThat(claimedKadaiTask.getOwner()).isEqualTo("admin");
+      kadaiEngine.getTaskService().claim(kadaiTask.getId());
 
-    camunda8TestUtil.waitUntil(
-        () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
-  }
+      final Task claimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(claimedKadaiTask.getOwner()).isEqualTo("admin");
+      assertThat(claimedKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.CLAIMED);
+      String externalId = kadaiTask.getExternalId();
+      long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
+      camunda8TestUtil.waitUntil(
+          () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+    }
 
-  @Test
-  @WithAccessId(user = "admin")
-  void should_CancelClaimCamundaTask_When_KadaiTaskIsCancelClaimed() throws Exception {
-    kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
-    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
+    @Test
+    @WithAccessId(user = "admin")
+    void should_ClaimAlreadyClaimedCamundaTask_When_ClaimKadaiTask() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
 
-    final ProcessInstanceEvent processInstance =
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId("Test_Process")
-            .latestVersion()
-            .send()
-            .join();
+      // create new Tenant and add user to it (user needs access to all tenants)
+      final String tenant1 = "tenant1";
+      final String allTenantsUser = "demo";
+      client.newCreateTenantCommand().tenantId(tenant1).name(tenant1).send().join();
+      client
+          .newAssignUserToTenantCommand()
+          .username(allTenantsUser)
+          .tenantId(tenant1)
+          .send()
+          .join();
 
-    CamundaAssert.assertThat(processInstance).isActive();
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .send()
+          .join();
 
-    final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
-    assertThat(tasks).hasSize(1);
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .send()
+              .join();
 
-    final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
+      CamundaAssert.assertThat(processInstance).isActive();
 
-    kadaiEngine.getTaskService().claim(kadaiTask.getId());
+      final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(tasks).hasSize(1);
 
-    final Task claimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
-    assertThat(claimedKadaiTask.getOwner()).isEqualTo("admin");
-    assertThat(claimedKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.CLAIMED);
+      final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
+      String externalId = kadaiTask.getExternalId();
+      long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
 
-    String externalId = kadaiTask.getExternalId();
-    long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
-    camunda8TestUtil.waitUntil(
-        () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+      camunda8TestUtil.assignCamundaTask(camundaTaskKey, "user-1-1");
+      camunda8TestUtil.waitUntil(
+          () -> "user-1-1".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
 
-    kadaiEngine.getTaskService().cancelClaim(kadaiTask.getId());
-    Task cancelClaimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
-    assertThat(cancelClaimedKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.READY);
-    camunda8TestUtil.waitUntil(
-        () -> camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey) == null);
-  }
+      assertThat(kadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.READY);
+      kadaiEngine.getTaskService().claim(kadaiTask.getId());
 
-  @Test
-  @WithAccessId(user = "admin")
-  void should_ClaimCamundaTaskAgain_When_ClaimKadaiTaskAfterCancelClaim() throws Exception {
-    kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
-    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+      final Task claimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(claimedKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.CLAIMED);
+      assertThat(claimedKadaiTask.getOwner()).isEqualTo("admin");
 
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
+      camunda8TestUtil.waitUntil(
+          () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+    }
 
-    final ProcessInstanceEvent processInstance =
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId("Test_Process")
-            .latestVersion()
-            .send()
-            .join();
+    @Test
+    @WithAccessId(user = "admin")
+    void should_CancelClaimCamundaTask_When_KadaiTaskIsCancelClaimed() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
 
-    CamundaAssert.assertThat(processInstance).isActive();
+      // create new Tenant and add user to it (user needs access to all tenants)
+      final String tenant1 = "tenant1";
+      final String allTenantsUser = "demo";
+      client.newCreateTenantCommand().tenantId(tenant1).name(tenant1).send().join();
+      client
+          .newAssignUserToTenantCommand()
+          .username(allTenantsUser)
+          .tenantId(tenant1)
+          .send()
+          .join();
 
-    final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
-    assertThat(tasks).hasSize(1);
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .tenantId(tenant1)
+          .send()
+          .join();
 
-    final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
-    String externalId = kadaiTask.getExternalId();
-    long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .tenantId(tenant1)
+              .send()
+              .join();
 
-    kadaiEngine.getTaskService().claim(kadaiTask.getId());
-    camunda8TestUtil.waitUntil(
-        () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+      CamundaAssert.assertThat(processInstance).isActive();
 
-    kadaiEngine.getTaskService().cancelClaim(kadaiTask.getId());
-    camunda8TestUtil.waitUntil(
-        () -> camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey) == null);
+      final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(tasks).hasSize(1);
 
-    kadaiEngine.getTaskService().claim(kadaiTask.getId());
-    Task finalKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
-    assertThat(finalKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.CLAIMED);
+      final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
 
-    camunda8TestUtil.waitUntil(
-        () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+      kadaiEngine.getTaskService().claim(kadaiTask.getId());
+
+      final Task claimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(claimedKadaiTask.getOwner()).isEqualTo("admin");
+      assertThat(claimedKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.CLAIMED);
+
+      String externalId = kadaiTask.getExternalId();
+      long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
+      camunda8TestUtil.waitUntil(
+          () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+
+      kadaiEngine.getTaskService().cancelClaim(kadaiTask.getId());
+      Task cancelClaimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(cancelClaimedKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.READY);
+      camunda8TestUtil.waitUntil(
+          () -> camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey) == null);
+    }
+
+    @Test
+    @WithAccessId(user = "admin")
+    void should_ClaimCamundaTaskAgain_When_ClaimKadaiTaskAfterCancelClaim() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+
+      // create new Tenant and add user to it (user needs access to all tenants)
+      final String tenant1 = "tenant1";
+      final String allTenantsUser = "demo";
+      client.newCreateTenantCommand().tenantId(tenant1).name(tenant1).send().join();
+      client
+          .newAssignUserToTenantCommand()
+          .username(allTenantsUser)
+          .tenantId(tenant1)
+          .send()
+          .join();
+
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .tenantId(tenant1)
+          .send()
+          .join();
+
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .tenantId(tenant1)
+              .send()
+              .join();
+
+      CamundaAssert.assertThat(processInstance).isActive();
+
+      final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(tasks).hasSize(1);
+
+      final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
+      String externalId = kadaiTask.getExternalId();
+      long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
+
+      kadaiEngine.getTaskService().claim(kadaiTask.getId());
+      camunda8TestUtil.waitUntil(
+          () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+
+      kadaiEngine.getTaskService().cancelClaim(kadaiTask.getId());
+      camunda8TestUtil.waitUntil(
+          () -> camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey) == null);
+
+      kadaiEngine.getTaskService().claim(kadaiTask.getId());
+      Task finalKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(finalKadaiTask.getState()).isEqualTo(io.kadai.task.api.TaskState.CLAIMED);
+
+      camunda8TestUtil.waitUntil(
+          () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+    }
   }
 }

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskCompleterTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskCompleterTest.java
@@ -14,55 +14,125 @@ import io.kadai.task.api.TaskState;
 import io.kadai.task.api.models.Task;
 import io.kadai.task.api.models.TaskSummary;
 import java.util.List;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * Tests for completing tasks from Kadai to Camunda 8. Tests the synchronisation of status when
  * tasks get completed in Kadai.
  */
-@KadaiAdapterCamunda8SpringBootTest
+@DirtiesContext
 class Camunda8TaskCompleterTest {
-  @Autowired Camunda8TestUtil camunda8TestUtil;
-  @Autowired private CamundaClient client;
-  @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
-  @Autowired private KadaiEngine kadaiEngine;
 
-  @Test
-  @WithAccessId(user = "admin")
-  void should_CompleteCamundaTask_When_KadaiTaskIsCompleted() throws Exception {
-    kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
-    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
+  @Nested
+  @KadaiAdapterCamunda8SpringBootTest
+  class NoMultiTenancyCamunda8TaskCompleterTest {
+    @Autowired Camunda8TestUtil camunda8TestUtil;
+    @Autowired private CamundaClient client;
+    @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
+    @Autowired private KadaiEngine kadaiEngine;
 
-    final ProcessInstanceEvent processInstance =
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId("Test_Process")
-            .latestVersion()
-            .send()
-            .join();
+    @Test
+    @WithAccessId(user = "admin")
+    void should_CompleteCamundaTask_When_KadaiTaskIsCompleted() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .send()
+          .join();
 
-    CamundaAssert.assertThat(processInstance).isActive();
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .send()
+              .join();
 
-    final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
-    assertThat(tasks).hasSize(1);
+      CamundaAssert.assertThat(processInstance).isActive();
 
-    final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
+      final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(tasks).hasSize(1);
 
-    kadaiEngine.getTaskService().claim(kadaiTask.getId());
-    kadaiEngine.getTaskService().completeTask(kadaiTask.getId());
+      final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
 
-    final Task completedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
-    assertThat(completedKadaiTask.getState()).isEqualTo(TaskState.COMPLETED);
-    String externalId = kadaiTask.getExternalId();
+      kadaiEngine.getTaskService().claim(kadaiTask.getId());
+      kadaiEngine.getTaskService().completeTask(kadaiTask.getId());
 
-    long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
-    camunda8TestUtil.waitUntil(
-        () -> "COMPLETED".equals(camunda8TestUtil.getCamundaTaskStatus(camundaTaskKey)));
+      final Task completedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(completedKadaiTask.getState()).isEqualTo(TaskState.COMPLETED);
+      String externalId = kadaiTask.getExternalId();
+
+      long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
+      camunda8TestUtil.waitUntil(
+          () -> "COMPLETED".equals(camunda8TestUtil.getCamundaTaskStatus(camundaTaskKey)));
+    }
+  }
+
+  @Nested
+  @TestPropertySource("classpath:camunda8-mt-test-application.properties")
+  @KadaiAdapterCamunda8SpringBootTest
+  class MultiTenancyCamunda8TaskCompleterTest {
+    @Autowired Camunda8TestUtil camunda8TestUtil;
+    @Autowired private CamundaClient client;
+    @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
+    @Autowired private KadaiEngine kadaiEngine;
+
+    @Test
+    @WithAccessId(user = "admin")
+    void should_CompleteCamundaTask_When_KadaiTaskIsCompleted() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+
+      // create new Tenant and add user to it (user needs access to all tenants)
+      final String tenant1 = "tenant1";
+      final String allTenantsUser = "demo";
+      client.newCreateTenantCommand().tenantId(tenant1).name(tenant1).send().join();
+      client
+          .newAssignUserToTenantCommand()
+          .username(allTenantsUser)
+          .tenantId(tenant1)
+          .send()
+          .join();
+
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .tenantId(tenant1)
+          .send()
+          .join();
+
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .tenantId(tenant1)
+              .send()
+              .join();
+
+      CamundaAssert.assertThat(processInstance).isActive();
+
+      final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(tasks).hasSize(1);
+
+      final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
+
+      kadaiEngine.getTaskService().claim(kadaiTask.getId());
+      kadaiEngine.getTaskService().completeTask(kadaiTask.getId());
+
+      final Task completedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(completedKadaiTask.getState()).isEqualTo(TaskState.COMPLETED);
+      String externalId = kadaiTask.getExternalId();
+
+      long camundaTaskKey = Long.parseLong(externalId.substring(externalId.lastIndexOf("-") + 1));
+      camunda8TestUtil.waitUntil(
+          () -> "COMPLETED".equals(camunda8TestUtil.getCamundaTaskStatus(camundaTaskKey)));
+    }
   }
 }

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCancellationTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCancellationTest.java
@@ -13,16 +13,21 @@ import io.kadai.task.api.TaskState;
 import io.kadai.task.api.models.Task;
 import io.kadai.task.api.models.TaskSummary;
 import java.util.List;
+import org.junit.jupiter.api.ClassOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
 @DirtiesContext
+@TestClassOrder(OrderAnnotation.class)
 class UserTaskCancellationTest {
 
   @Nested
+  @Order(1)
   @KadaiAdapterCamunda8SpringBootTest
   class NoMultiTenancyUserTaskCancellationTest {
     @Autowired private CamundaClient client;
@@ -67,6 +72,7 @@ class UserTaskCancellationTest {
   }
 
   @Nested
+  @Order(2)
   @TestPropertySource("classpath:camunda8-mt-test-application.properties")
   @KadaiAdapterCamunda8SpringBootTest
   class MultiTenancyUserTaskCancellationTest {

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCancellationTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCancellationTest.java
@@ -13,16 +13,21 @@ import io.kadai.task.api.TaskState;
 import io.kadai.task.api.models.Task;
 import io.kadai.task.api.models.TaskSummary;
 import java.util.List;
+import org.junit.jupiter.api.ClassOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
 @DirtiesContext
+@TestClassOrder(OrderAnnotation.class)
 class UserTaskCancellationTest {
 
   @Nested
+  @Order(1)
   @KadaiAdapterCamunda8SpringBootTest
   class NoMultiTenancyUserTaskCancellationTest {
     @Autowired private CamundaClient client;
@@ -67,6 +72,7 @@ class UserTaskCancellationTest {
   }
 
   @Nested
+  @Order(2)
   @TestPropertySource("classpath:camunda8-mt-test-application.properties")
   @KadaiAdapterCamunda8SpringBootTest
   class MultiTenancyUserTaskCancellationTest {
@@ -81,11 +87,16 @@ class UserTaskCancellationTest {
       kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
       kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
 
-      // create new Tenant and add user to it
+      // create new Tenant and add user to it (user needs access to all tenants)
       final String tenant1 = "tenant1";
       final String allTenantsUser = "demo";
-      client.newCreateTenantCommand().tenantId(tenant1).name(tenant1).execute();
-      client.newAssignUserToTenantCommand().username(allTenantsUser).tenantId(tenant1).execute();
+      client.newCreateTenantCommand().tenantId(tenant1).name(tenant1).send().join();
+      client
+          .newAssignUserToTenantCommand()
+          .username(allTenantsUser)
+          .tenantId(tenant1)
+          .send()
+          .join();
 
       client
           .newDeployResourceCommand()

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCancellationTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCancellationTest.java
@@ -13,49 +13,110 @@ import io.kadai.task.api.TaskState;
 import io.kadai.task.api.models.Task;
 import io.kadai.task.api.models.TaskSummary;
 import java.util.List;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 
-@KadaiAdapterCamunda8SpringBootTest
+@DirtiesContext
 class UserTaskCancellationTest {
 
-  @Autowired private CamundaClient client;
-  @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
-  @Autowired private KadaiEngine kadaiEngine;
+  @Nested
+  @KadaiAdapterCamunda8SpringBootTest
+  class NoMultiTenancyUserTaskCancellationTest {
+    @Autowired private CamundaClient client;
+    @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
+    @Autowired private KadaiEngine kadaiEngine;
 
-  @Test
-  @WithAccessId(user = "admin")
-  void should_CancelKadaiTask_When_CamundaTaskIsCompleted() throws Exception {
-    kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
-    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+    @Test
+    @WithAccessId(user = "admin")
+    void should_CancelKadaiTask_When_CamundaTaskIsCompleted() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
 
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .send()
+          .join();
 
-    final ProcessInstanceEvent processInstance =
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId("Test_Process")
-            .latestVersion()
-            .send()
-            .join();
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .send()
+              .join();
 
-    CamundaAssert.assertThat(processInstance).isActive();
+      CamundaAssert.assertThat(processInstance).isActive();
 
-    final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
-    assertThat(tasks).hasSize(1);
-    assertThat(tasks.get(0).getState()).isEqualTo(TaskState.READY);
+      final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(tasks).hasSize(1);
+      assertThat(tasks.get(0).getState()).isEqualTo(TaskState.READY);
 
-    final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
+      final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
 
-    client.newCancelInstanceCommand(processInstance.getProcessInstanceKey()).send().join();
+      client.newCancelInstanceCommand(processInstance.getProcessInstanceKey()).send().join();
 
-    Thread.sleep(100);
+      Thread.sleep(100);
 
-    final Task canceledTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
-    assertThat(canceledTask.getState()).isEqualTo(TaskState.CANCELLED);
+      final Task canceledTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(canceledTask.getState()).isEqualTo(TaskState.CANCELLED);
+    }
+  }
+
+  @Nested
+  @TestPropertySource("classpath:camunda8-mt-test-application.properties")
+  @KadaiAdapterCamunda8SpringBootTest
+  class MultiTenancyUserTaskCancellationTest {
+
+    @Autowired private CamundaClient client;
+    @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
+    @Autowired private KadaiEngine kadaiEngine;
+
+    @Test
+    @WithAccessId(user = "admin")
+    void should_CancelKadaiTask_When_CamundaTaskIsCompleted() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+
+      // create new Tenant and add user to it
+      final String tenant1 = "tenant1";
+      final String allTenantsUser = "demo";
+      client.newCreateTenantCommand().tenantId(tenant1).name(tenant1).execute();
+      client.newAssignUserToTenantCommand().username(allTenantsUser).tenantId(tenant1).execute();
+
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .tenantId(tenant1)
+          .send()
+          .join();
+
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .tenantId(tenant1)
+              .send()
+              .join();
+
+      CamundaAssert.assertThat(processInstance).isActive();
+
+      final List<TaskSummary> tasks = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(tasks).hasSize(1);
+      assertThat(tasks.get(0).getState()).isEqualTo(TaskState.READY);
+
+      final Task kadaiTask = kadaiEngine.getTaskService().getTask(tasks.get(0).getId());
+
+      client.newCancelInstanceCommand(processInstance.getProcessInstanceKey()).send().join();
+
+      Thread.sleep(100);
+
+      final Task canceledTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+      assertThat(canceledTask.getState()).isEqualTo(TaskState.CANCELLED);
+    }
   }
 }

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCreationTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCreationTest.java
@@ -12,67 +12,155 @@ import io.kadai.common.test.security.WithAccessId;
 import io.kadai.task.api.TaskState;
 import io.kadai.task.api.models.TaskSummary;
 import java.util.List;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 
-@KadaiAdapterCamunda8SpringBootTest
+@DirtiesContext
 class UserTaskCreationTest {
 
-  @Autowired private CamundaClient client;
-  @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
-  @Autowired private KadaiEngine kadaiEngine;
+  @KadaiAdapterCamunda8SpringBootTest
+  @Nested
+  class NoMultiTenancyUserTaskCreationTest {
+    @Autowired private CamundaClient client;
+    @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
+    @Autowired private KadaiEngine kadaiEngine;
 
-  @Test
-  @WithAccessId(user = "admin")
-  void should_CreateKadaiTask() throws Exception {
-    kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
-    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
+    @Test
+    @WithAccessId(user = "admin")
+    void should_CreateKadaiTask() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .send()
+          .join();
 
-    final ProcessInstanceEvent processInstance =
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId("Test_Process")
-            .latestVersion()
-            .send()
-            .join();
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .send()
+              .join();
 
-    CamundaAssert.assertThat(processInstance).isActive();
-    final List<TaskSummary> actual = kadaiEngine.getTaskService().createTaskQuery().list();
-    assertThat(actual).hasSize(1);
-    TaskSummary kadaiTask = actual.get(0);
-    assertThat(kadaiTask.getState()).isEqualTo(TaskState.READY);
-    assertThat(kadaiTask.getWorkbasketSummary().getKey()).isEqualTo("GPK_KSC");
-    assertThat(kadaiTask.getClassificationSummary().getKey()).isEqualTo("L11010");
-    assertThat(kadaiTask.getDomain()).isEqualTo("DOMAIN_A");
-    assertThat(kadaiTask.getName()).isEqualTo("Say Hello Task");
+      CamundaAssert.assertThat(processInstance).isActive();
+      final List<TaskSummary> actual = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(actual).hasSize(1);
+      TaskSummary kadaiTask = actual.get(0);
+      assertThat(kadaiTask.getState()).isEqualTo(TaskState.READY);
+      assertThat(kadaiTask.getWorkbasketSummary().getKey()).isEqualTo("GPK_KSC");
+      assertThat(kadaiTask.getClassificationSummary().getKey()).isEqualTo("L11010");
+      assertThat(kadaiTask.getDomain()).isEqualTo("DOMAIN_A");
+      assertThat(kadaiTask.getName()).isEqualTo("Say Hello Task");
+    }
+
+    @Test
+    @WithAccessId(user = "admin")
+    void should_NotCreateKadaiTask_When_WorkbasketNotFound() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_UNKNOWN", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .send()
+          .join();
+
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .send()
+              .join();
+
+      CamundaAssert.assertThat(processInstance).isActive();
+      final List<TaskSummary> actual = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(actual).isEmpty();
+    }
   }
 
-  @Test
-  @WithAccessId(user = "admin")
-  void should_NotCreateKadaiTask_When_WorkbasketNotFound() throws Exception {
-    kadaiAdapterTestUtil.createWorkbasket("GPK_UNKNOWN", "DOMAIN_A");
-    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
+  @Nested
+  @TestPropertySource("classpath:camunda8-mt-test-application.properties")
+  @KadaiAdapterCamunda8SpringBootTest
+  class MultiTenancyUserTaskCreationTest {
 
-    final ProcessInstanceEvent processInstance =
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId("Test_Process")
-            .latestVersion()
-            .send()
-            .join();
+    @Autowired private CamundaClient client;
+    @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
+    @Autowired private KadaiEngine kadaiEngine;
 
-    CamundaAssert.assertThat(processInstance).isActive();
-    final List<TaskSummary> actual = kadaiEngine.getTaskService().createTaskQuery().list();
-    assertThat(actual).isEmpty();
+    @Test
+    @WithAccessId(user = "admin")
+    void should_CreateKadaiTask() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+
+      final String tenant1 = "tenant1";
+      final String allTenantsUser = "demo";
+      client.newCreateTenantCommand().tenantId(tenant1).name(tenant1).execute();
+      client.newAssignUserToTenantCommand().username(allTenantsUser).tenantId(tenant1).execute();
+
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .tenantId(tenant1)
+          .send()
+          .join();
+
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .tenantId(tenant1)
+              .send()
+              .join();
+
+      CamundaAssert.assertThat(processInstance).isActive();
+      final List<TaskSummary> actual = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(actual).hasSize(1);
+      TaskSummary kadaiTask = actual.get(0);
+      assertThat(kadaiTask.getState()).isEqualTo(TaskState.READY);
+      assertThat(kadaiTask.getWorkbasketSummary().getKey()).isEqualTo("GPK_KSC");
+      assertThat(kadaiTask.getClassificationSummary().getKey()).isEqualTo("L11010");
+      assertThat(kadaiTask.getDomain()).isEqualTo("DOMAIN_A");
+      assertThat(kadaiTask.getName()).isEqualTo("Say Hello Task");
+    }
+
+    @Test
+    @WithAccessId(user = "admin")
+    void should_NotCreateKadaiTask_When_WorkbasketNotFound() throws Exception {
+      kadaiAdapterTestUtil.createWorkbasket("GPK_UNKNOWN", "DOMAIN_A");
+      kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+
+      final String defaultTenant = "<default>";
+      final String tenant1 = "tenant1";
+      final String allTenantsUser = "demo";
+      client.newCreateTenantCommand().tenantId(tenant1).name(tenant1).execute();
+      client.newAssignUserToTenantCommand().username(allTenantsUser).tenantId(tenant1).execute();
+
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("processes/sayHello.bpmn")
+          .tenantId(defaultTenant)
+          .send()
+          .join();
+
+      final ProcessInstanceEvent processInstance =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId("Test_Process")
+              .latestVersion()
+              .tenantId(defaultTenant)
+              .send()
+              .join();
+
+      CamundaAssert.assertThat(processInstance).isActive();
+      final List<TaskSummary> actual = kadaiEngine.getTaskService().createTaskQuery().list();
+      assertThat(actual).isEmpty();
+    }
   }
 }

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/camunda8-mt-test-application.properties
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/camunda8-mt-test-application.properties
@@ -3,5 +3,3 @@
 ####################################################################################
 camunda.process-test.multi-tenancy-enabled=true
 camunda.client.worker.defaults.tenant-ids=tenant1,<default>
-camunda.client.auth.username=demo
-camunda.client.auth.password=demo

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/camunda8-mt-test-application.properties
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/camunda8-mt-test-application.properties
@@ -1,0 +1,8 @@
+####################################################################################
+# Camunda 8 properties - Multi-Tenancy
+####################################################################################
+camunda.process-test.multi-tenancy-enabled=true
+camunda.client.worker.defaults.tenant-ids=tenant1,<default>
+# security
+camunda.security.user=demo
+camunda.security.password=demo

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/camunda8-mt-test-application.properties
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/camunda8-mt-test-application.properties
@@ -3,6 +3,5 @@
 ####################################################################################
 camunda.process-test.multi-tenancy-enabled=true
 camunda.client.worker.defaults.tenant-ids=tenant1,<default>
-# security
-camunda.security.user=demo
-camunda.security.password=demo
+camunda.client.auth.username=demo
+camunda.client.auth.password=demo


### PR DESCRIPTION
- adds acceptance tests for a multi-tenancy setups
- adds springboot example with fitting properties for multi-tenancy

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it: [Pull Request in kadai-doc](https://github.com/kadai-io/kadai-doc/pull/173)
- [x] If extra release-notes are required, they're listed indented below: