### PR TITLE
Closes #368 - Fix Camunda 8 JSON-Variables Parse-Error for String

### DIFF
--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/processes/sayHello.bpmn
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/processes/sayHello.bpmn
@@ -25,7 +25,7 @@
           <zeebe:input source="=&#34;L11010&#34;" target="kadai_classification_key" />
           <zeebe:input source="=&#34;DOMAIN_A&#34;" target="kadai_domain" />
           <zeebe:input source="=&#34;attr1,attr2&#34;" target="kadai_attributes" />
-          <zeebe:input source="=&#34;1&#34;" target="attr1" />
+          <zeebe:input source="=&#34;foo&#34;" target="attr1" />
           <zeebe:input source="=&#34;2&#34;" target="attr2" />
           <zeebe:input source="=&#34;Say Hello Task&#34;" target="kadai_name" />
         </zeebe:ioMapping>

--- a/kadai-adapter-camunda8-parent/pom.xml
+++ b/kadai-adapter-camunda8-parent/pom.xml
@@ -26,5 +26,6 @@
   <modules>
     <module>kadai-adapter-camunda-8-system-connector</module>
     <module>kadai-adapter-camunda-8-spring-boot-example</module>
+    <module>kadai-adapter-camunda-8-spring-boot-multi-tenancy-example</module>
   </modules>
 </project>

--- a/kadai-adapter-kadai-connector/src/main/java/io/kadai/adapter/kadaiconnector/api/impl/TaskInformationMapper.java
+++ b/kadai-adapter-kadai-connector/src/main/java/io/kadai/adapter/kadaiconnector/api/impl/TaskInformationMapper.java
@@ -44,6 +44,7 @@ public class TaskInformationMapper {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TaskInformationMapper.class);
   private static final String CAMUNDA_PROCESS_VARIABLE_PREFIX = "camunda:";
+  private final TaskService taskService;
 
   @Value("${kadai.adapter.mapping.default.objectreference.company:DEFAULT_COMPANY}")
   private String defaultCompany;
@@ -59,8 +60,6 @@ public class TaskInformationMapper {
 
   @Value("${kadai.adapter.mapping.default.objectreference.value:DEFAULT_VALUE}")
   private String defaultValue;
-
-  private final TaskService taskService;
 
   public TaskInformationMapper(TaskService taskService) {
     this.taskService = taskService;
@@ -186,7 +185,6 @@ public class TaskInformationMapper {
 
   private Map<String, String> retrieveCustomAttributesFromProcessVariables(
       String processVariables) {
-
     Map<String, String> customAttributes = new HashMap<>();
 
     JSONObject jsonObject = new JSONObject(processVariables);
@@ -194,9 +192,12 @@ public class TaskInformationMapper {
     jsonObject
         .keySet()
         .forEach(
-            key ->
-                customAttributes.put(
-                    CAMUNDA_PROCESS_VARIABLE_PREFIX + key, String.valueOf(jsonObject.get(key))));
+            key -> {
+              final Object value = jsonObject.get(key);
+              final String formattedValue =
+                  value instanceof String s ? String.format("\"%s\"", s) : String.valueOf(value);
+              customAttributes.put(CAMUNDA_PROCESS_VARIABLE_PREFIX + key, formattedValue);
+            });
 
     return customAttributes;
   }


### PR DESCRIPTION
The problem was in mapping Camunda-Process-Variables to Kadai custom-attributes.
Strings were not properly enclosed with extra quotes and therefore could not be parsed back into JSON downstream.

The code fixed here is shared between all plugins as it's part of the `kadai-connector`.

The problem did not occur for Camunda 7 as JSON-Values are always JSON-Objects there, e.g. custom-attributes looked like this:
```bash
{camunda:attribute2={"valueInfo":null,"type":"integer","value":5}, camunda:attribute1={"valueInfo":{"objectTypeName":"io.kadai.impl.ProcessVariableTestObject","serializationDataFormat":"application/json"},"type":"object","value":"{\"stringField\":\"\\fForm feed \\b Backspace \\t Tab \\\\Backslash \\n newLine \\r Carriage return \\\" DoubleQuote\",\"intField\":1,\"doubleField\":1.1,\"booleanField\":false,\"processVariableTestObjectTwoField\":[{\"stringFieldObjectTwo\":\"stringValueObjectTwo\",\"intFieldObjectTwo\":2,\"doubleFieldObjectTwo\":2.2,\"booleanFieldObjectTwo\":true,\"dateFieldObjectTwo\":\"1970-01-01 13:12:11\"}]}"}, camunda:attribute3={"valueInfo":null,"type":"boolean","value":true}}
```

In Camunda 8 these are plain JSON and therefore flat. That lead to previous custom-attributes:
```bash
{camunda:attribute1="42", camunda:attribute2="foo"}
```

After applying the fix this leads to:
```bash
{camunda:attribute1="42", camunda:attribute2="\"foo\""}
```

<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: