### PR TITLE
Closes #420 - Fix enforcement of Transaction-Boundaries on Cluster-Locking

### DIFF
--- a/kadai-adapter-camunda-outbox-rest/src/main/java/io/kadai/adapter/camunda/outbox/rest/service/CamundaTaskEventsService.java
+++ b/kadai-adapter-camunda-outbox-rest/src/main/java/io/kadai/adapter/camunda/outbox/rest/service/CamundaTaskEventsService.java
@@ -466,8 +466,8 @@ public class CamundaTaskEventsService {
             LOGGER.error("Failed to unlock events", ex);
           }
         }
+        connection.rollback();
       }
-      connection.rollback();
     } catch (SQLException | NullPointerException e) {
       LOGGER.warn("Caught Exception while trying to retrieve create events from the outbox", e);
     }

--- a/kadai-adapter-camunda-outbox-rest/src/main/java/io/kadai/adapter/camunda/outbox/rest/service/CamundaTaskEventsService.java
+++ b/kadai-adapter-camunda-outbox-rest/src/main/java/io/kadai/adapter/camunda/outbox/rest/service/CamundaTaskEventsService.java
@@ -582,6 +582,11 @@ public class CamundaTaskEventsService {
     Connection connection = null;
     try {
       connection = OutboxDataSource.get().getConnection();
+      if (!connection.getAutoCommit()) {
+        LOGGER.warn(
+            "Connection may already be participating in transaction provided by surrounding "
+                + "transaction-manager. Transaction may not behave correctly.");
+      }
       connection.setAutoCommit(autoCommit);
     } catch (SQLException | NullPointerException e) {
       LOGGER.warn(

--- a/kadai-adapter-camunda-outbox-rest/src/main/java/io/kadai/adapter/camunda/outbox/rest/service/CamundaTaskEventsService.java
+++ b/kadai-adapter-camunda-outbox-rest/src/main/java/io/kadai/adapter/camunda/outbox/rest/service/CamundaTaskEventsService.java
@@ -428,7 +428,7 @@ public class CamundaTaskEventsService {
     List<CamundaTaskEvent> camundaTaskEvents = new ArrayList<>();
     List<Integer> ids = null;
 
-    try (Connection connection = getConnection()) {
+    try (Connection connection = getConnection(false)) {
       final CamundaOutboxSqlProvider sqlProvider =
           CamundaOutboxSqlProvider.valueOf(connection.getMetaData().getDatabaseProductName());
       String sql =
@@ -445,6 +445,7 @@ public class CamundaTaskEventsService {
         camundaTaskEvents = getCamundaTaskEvents(camundaTaskEventResultSet);
         ids = camundaTaskEvents.stream().map(CamundaTaskEvent::getId).collect(Collectors.toList());
         lockEvents(ids, lockDuration, connection);
+        connection.commit();
         if (LOGGER.isDebugEnabled()) {
           LOGGER.debug(
               "Events locked: {}",
@@ -465,6 +466,7 @@ public class CamundaTaskEventsService {
           }
         }
       }
+      connection.rollback();
     } catch (SQLException | NullPointerException e) {
       LOGGER.warn("Caught Exception while trying to retrieve create events from the outbox", e);
     }
@@ -575,10 +577,11 @@ public class CamundaTaskEventsService {
     return camundaTaskEvents;
   }
 
-  private Connection getConnection() {
+  private Connection getConnection(boolean autoCommit) {
     Connection connection = null;
     try {
       connection = OutboxDataSource.get().getConnection();
+      connection.setAutoCommit(autoCommit);
     } catch (SQLException | NullPointerException e) {
       LOGGER.warn(
           "Caught {} while trying to retrieve a connection from the provided datasource",
@@ -591,6 +594,10 @@ public class CamundaTaskEventsService {
           "Retrieved connection was NULL. Please make sure to provide a valid datasource.");
     }
     return connection;
+  }
+
+  private Connection getConnection() {
+    return getConnection(true);
   }
 
   private void unlockEvents(List<Integer> ids, Connection connection) throws SQLException {

--- a/kadai-adapter-camunda-outbox-rest/src/main/java/io/kadai/adapter/camunda/outbox/rest/service/CamundaTaskEventsService.java
+++ b/kadai-adapter-camunda-outbox-rest/src/main/java/io/kadai/adapter/camunda/outbox/rest/service/CamundaTaskEventsService.java
@@ -456,6 +456,7 @@ public class CamundaTaskEventsService {
         if (ids != null) {
           try {
             unlockEvents(ids, connection);
+            connection.commit();
             if (LOGGER.isDebugEnabled()) {
               LOGGER.debug(
                   "Events unlocked: {}",


### PR DESCRIPTION
NB: Test `TestLockingAndClustering::should_CreateCorrespondingKadaiTasksConcurrently` used to fail locally. With this fix it always passes. (endorsing this change further)

<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [ ] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: