### PR TITLE
Closes #396 - replace manual C8 int-test process-deployment with `@TestDeployment`

### DIFF
--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskClaimerTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskClaimerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.TestDeployment;
 import io.kadai.adapter.systemconnector.camunda.Camunda8TestUtil;
 import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
 import io.kadai.adapter.systemconnector.camunda.tasklistener.util.ReferencedTaskCreator;
@@ -34,14 +35,10 @@ class Camunda8TaskClaimerTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_ClaimCamundaTask_When_KadaiTaskIsClaimed() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client
@@ -72,15 +69,10 @@ class Camunda8TaskClaimerTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_ClaimAlreadyClaimedCamundaTask_When_ClaimKadaiTask() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client
@@ -117,14 +109,10 @@ class Camunda8TaskClaimerTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_CancelClaimCamundaTask_When_KadaiTaskIsCancelClaimed() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client
@@ -162,15 +150,10 @@ class Camunda8TaskClaimerTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_ClaimCamundaTaskAgain_When_ClaimKadaiTaskAfterCancelClaim() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskCompleterTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/api/impl/Camunda8TaskCompleterTest.java
@@ -10,6 +10,7 @@ import io.camunda.client.api.search.response.Variable;
 import io.camunda.client.api.worker.JobHandler;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.TestDeployment;
 import io.kadai.adapter.systemconnector.camunda.Camunda8TestUtil;
 import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
 import io.kadai.adapter.systemconnector.camunda.tasklistener.util.ReferencedTaskCreator;
@@ -39,14 +40,10 @@ class Camunda8TaskCompleterTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_CompleteCamundaTask_When_KadaiTaskIsCompleted() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client
@@ -79,14 +76,10 @@ class Camunda8TaskCompleterTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHelloThenBye.bpmn")
   void should_PropagateNewVariablesToProcessContext_When_KadaiTaskIsCompleted() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHelloThenBye.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client
@@ -144,6 +137,7 @@ class Camunda8TaskCompleterTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_SetCompletedByKadaiAction_When_KadaiTaskIsCompleted() throws Exception {
     final JobHandler verificationHandler =
         (jobClient, job) -> {
@@ -160,11 +154,6 @@ class Camunda8TaskCompleterTest {
             .open()) {
       kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
       kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-      client
-          .newDeployResourceCommand()
-          .addResourceFromClasspath("processes/sayHello.bpmn")
-          .send()
-          .join();
 
       final ProcessInstanceEvent processInstance =
           client
@@ -194,14 +183,10 @@ class Camunda8TaskCompleterTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_CancelCamundaTask_When_KadaiTaskIsCancelled() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client
@@ -233,6 +218,7 @@ class Camunda8TaskCompleterTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_SetCompletedByKadaiAction_When_KadaiTaskIsCancelled() throws Exception {
     final JobHandler verificationHandler =
         (jobClient, job) -> {
@@ -249,11 +235,6 @@ class Camunda8TaskCompleterTest {
             .open()) {
       kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
       kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-      client
-          .newDeployResourceCommand()
-          .addResourceFromClasspath("processes/sayHello.bpmn")
-          .send()
-          .join();
 
       final ProcessInstanceEvent processInstance =
           client

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/monitoring/Camunda8CompositeHealthIntTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/monitoring/Camunda8CompositeHealthIntTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.process.test.api.TestDeployment;
 import io.kadai.adapter.systemconnector.camunda.Camunda8TestUtil;
 import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
 import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCreation;
@@ -36,15 +37,11 @@ class Camunda8CompositeHealthIntTest {
   class Camunda8CompositeUp {
     @Test
     @WithAccessId(user = "admin")
+    @TestDeployment(resources = "processes/sayHello.bpmn")
     void should_ReturnUp_When_AnyJobWorkerRanSuccessfullyAndAllOthersHaveNotAtAll()
         throws Exception {
       kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
       kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-      client
-          .newDeployResourceCommand()
-          .addResourceFromClasspath("processes/sayHello.bpmn")
-          .send()
-          .join();
 
       client.newCreateInstanceCommand().bpmnProcessId("Test_Process").latestVersion().send().join();
 
@@ -102,13 +99,8 @@ class Camunda8CompositeHealthIntTest {
 
     @Test
     @WithAccessId(user = "admin")
+    @TestDeployment(resources = "processes/sayHello.bpmn")
     void should_ReturnDown_When_AnyJobWorkerRanWithError() {
-      client
-          .newDeployResourceCommand()
-          .addResourceFromClasspath("processes/sayHello.bpmn")
-          .send()
-          .join();
-
       // workbasket doesn't exist => failure
       client.newCreateInstanceCommand().bpmnProcessId("Test_Process").latestVersion().send().join();
 

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCancellationTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCancellationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.TestDeployment;
 import io.kadai.adapter.impl.util.UserContext;
 import io.kadai.adapter.systemconnector.camunda.Camunda8TestUtil;
 import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
@@ -30,15 +31,10 @@ class UserTaskCancellationTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_CancelKadaiTask_When_CamundaTaskIsCompleted() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCompletionTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCompletionTest.java
@@ -7,6 +7,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.TestDeployment;
 import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
 import io.kadai.adapter.systemconnector.camunda.tasklistener.util.ReferencedTaskCreator;
 import io.kadai.adapter.test.KadaiAdapterTestUtil;
@@ -30,15 +31,10 @@ class UserTaskCompletionTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_CompleteKadaiTask_When_CamundaTaskIsCompleted() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client
@@ -68,15 +64,10 @@ class UserTaskCompletionTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_BeIdempotent_When_TaskCompletedTwice() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCreationTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/tasklistener/UserTaskCreationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.TestDeployment;
 import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
 import io.kadai.adapter.test.KadaiAdapterTestUtil;
 import io.kadai.common.api.KadaiEngine;
@@ -26,14 +27,10 @@ class UserTaskCreationTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_CreateKadaiTask_When_KadaiDomainIsDeclaredInUserTask() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client
@@ -56,14 +53,10 @@ class UserTaskCreationTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHelloNoKadaiDomainOnUserTask.bpmn")
   void should_CreateKadaiTask_When_KadaiDomainIsDeclaredInProcessInstance() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHelloNoKadaiDomainOnUserTask.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client
@@ -93,14 +86,10 @@ class UserTaskCreationTest {
 
   @Test
   @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_NotCreateKadaiTask_When_WorkbasketNotFound() throws Exception {
     kadaiAdapterTestUtil.createWorkbasket("GPK_UNKNOWN", "DOMAIN_A");
     kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-    client
-        .newDeployResourceCommand()
-        .addResourceFromClasspath("processes/sayHello.bpmn")
-        .send()
-        .join();
 
     final ProcessInstanceEvent processInstance =
         client


### PR DESCRIPTION
Only remaining manual-deployment test is the `MultiTenancyTest` which cannot be sugared as of now.
See feat-req https://github.com/camunda/camunda/issues/57689

<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: