### PR TITLE
Closes #416 - Add C8 Acceptane-Test for minimal Camunda permissions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -207,7 +207,7 @@ jobs:
   build:
     name: Compile all Maven modules with Java 21
     runs-on: ubuntu-22.04
-    needs: [detect_changes]
+    needs: [ detect_changes ]
     if: needs.detect_changes.outputs.code_changed == 'true' || startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Start Eco CI Measurement
@@ -268,7 +268,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     name: Test ${{ matrix.module }} with Java ${{ matrix.java_version }}
-    needs: [detect_changes, build]
+    needs: [ detect_changes, build ]
     if: needs.detect_changes.outputs.code_changed == 'true' || startsWith(github.ref, 'refs/tags/')
     strategy:
       fail-fast: false
@@ -342,7 +342,7 @@ jobs:
   release_artifacts:
     runs-on: ubuntu-22.04
     name: Release artifacts to Sonatype-Central
-    needs: [detect_changes, test]
+    needs: [ detect_changes, test ]
     if: |
       always() &&
       github.repository == 'kadai-io/KadaiAdapter' &&
@@ -458,7 +458,7 @@ jobs:
   upload_to_sonar:
     runs-on: ubuntu-22.04
     name: Upload SonarQube analysis to SonarCloud
-    needs: [detect_changes, test]
+    needs: [ detect_changes, test ]
     if: |
       always() &&
       github.repository == 'kadai-io/KadaiAdapter' &&

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/Camunda8TestUtil.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/Camunda8TestUtil.java
@@ -3,9 +3,13 @@ package io.kadai.adapter.systemconnector.camunda;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.search.response.UserTask;
+import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.ThrowingConsumer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +47,7 @@ public class Camunda8TestUtil {
       throw new RuntimeException("Failed to assign Camunda task", e);
     }
   }
-  
+
   public void waitUntil(Callable<Boolean> condition) {
     await()
         .pollInSameThread()
@@ -57,6 +61,39 @@ public class Camunda8TestUtil {
       return camundaClient.newUserTaskGetRequest(taskKey).send().join();
     } catch (Exception e) {
       throw new RuntimeException("Failed to get Camunda task", e);
+    }
+  }
+
+  public static boolean handleNextJob(
+      CamundaClient workerClient,
+      String workerName,
+      String tenantId,
+      String jobType,
+      ThrowingConsumer<ActivatedJob> handler) {
+    List<ActivatedJob> jobs =
+        workerClient
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(1)
+            .workerName(workerName)
+            .timeout(Duration.ofSeconds(30))
+            .tenantId(tenantId)
+            .requestTimeout(Duration.ofSeconds(1))
+            .send()
+            .join()
+            .getJobs();
+
+    if (jobs.isEmpty()) {
+      return false;
+    }
+
+    ActivatedJob job = jobs.get(0);
+    try {
+      handler.accept(job);
+      workerClient.newCompleteCommand(job).send().join();
+      return true;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to handle job type '" + jobType + "'", e);
     }
   }
 }

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/MultiTenancyTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/MultiTenancyTest.java
@@ -1,5 +1,6 @@
 package io.kadai.adapter.systemconnector.camunda;
 
+import static io.kadai.adapter.systemconnector.camunda.Camunda8TestUtil.handleNextJob;
 import static io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCompletion.USER_TASK_COMPLETED_JOB_WORKER_TYPE;
 import static io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCreation.USER_TASK_CREATED_JOB_WORKER_TYPE;
 import static io.kadai.adapter.systemconnector.camunda.tasklistener.util.ReferencedTaskCreator.extractUserTaskKeyFromTaskId;
@@ -143,40 +144,6 @@ class MultiTenancyTest {
     }
   }
 
-  private boolean handleNextJob(
-      CamundaClient workerClient,
-      String workerName,
-      String tenantId,
-      String jobType,
-      ThrowingActivatedJobConsumer handler) {
-    final List<ActivatedJob> jobs =
-        workerClient
-            .newActivateJobsCommand()
-            .jobType(jobType)
-            .maxJobsToActivate(1)
-            .workerName(workerName)
-            .timeout(Duration.ofSeconds(30))
-            .tenantId(tenantId)
-            .requestTimeout(Duration.ofSeconds(1))
-            .send()
-            .join()
-            .getJobs();
-
-    if (jobs.isEmpty()) {
-      return false;
-    }
-
-    final ActivatedJob job = jobs.get(0);
-    try {
-      handler.accept(job);
-      workerClient.newCompleteCommand(job).send().join();
-      return true;
-    } catch (Exception e) {
-      throw new RuntimeException(
-          "Failed to handle job type '" + jobType + "' for tenant '" + tenantId + "'", e);
-    }
-  }
-
   private Task getKadaiTask(String taskId) {
     try {
       return kadaiEngine.getTaskService().getTask(taskId);
@@ -247,10 +214,5 @@ class MultiTenancyTest {
         .tenantId(tenantId)
         .send()
         .join();
-  }
-
-  @FunctionalInterface
-  private interface ThrowingActivatedJobConsumer {
-    void accept(ActivatedJob job) throws Exception;
   }
 }

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/MultiTenancyTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/MultiTenancyTest.java
@@ -7,7 +7,6 @@ import static io.kadai.adapter.systemconnector.camunda.tasklistener.util.Referen
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.process.test.api.CamundaAssert;
@@ -19,8 +18,6 @@ import io.kadai.common.api.KadaiEngine;
 import io.kadai.common.test.security.WithAccessId;
 import io.kadai.task.api.TaskState;
 import io.kadai.task.api.models.Task;
-import java.time.Duration;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/MinimalPermissionsAccTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/MinimalPermissionsAccTest.java
@@ -1,0 +1,322 @@
+package io.kadai.adapter.systemconnector.camunda.acceptance;
+
+import static io.camunda.client.api.search.enums.PermissionType.CLAIM_USER_TASK;
+import static io.camunda.client.api.search.enums.PermissionType.COMPLETE_USER_TASK;
+import static io.camunda.client.api.search.enums.PermissionType.READ_USER_TASK;
+import static io.camunda.client.api.search.enums.PermissionType.UPDATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.UPDATE_USER_TASK;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCancellation.USER_TASK_CANCELLED_JOB_WORKER_TYPE;
+import static io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCompletion.USER_TASK_COMPLETED_JOB_WORKER_TYPE;
+import static io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCreation.USER_TASK_CREATED_JOB_WORKER_TYPE;
+import static io.kadai.adapter.systemconnector.camunda.tasklistener.util.ReferencedTaskCreator.extractUserTaskKeyFromTaskId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CredentialsProvider;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.TestDeployment;
+import io.kadai.adapter.manager.AdapterManager;
+import io.kadai.adapter.systemconnector.camunda.Camunda8TestUtil;
+import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
+import io.kadai.adapter.systemconnector.camunda.api.impl.Camunda8SystemConnectorImpl;
+import io.kadai.adapter.systemconnector.camunda.api.impl.Camunda8TaskClaimCanceler;
+import io.kadai.adapter.systemconnector.camunda.api.impl.Camunda8TaskClaimer;
+import io.kadai.adapter.systemconnector.camunda.api.impl.Camunda8TaskCompleter;
+import io.kadai.adapter.systemconnector.camunda.config.Camunda8System;
+import io.kadai.adapter.systemconnector.camunda.config.Camunda8SystemConnectorConfiguration;
+import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCancellation;
+import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCompletion;
+import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCreation;
+import io.kadai.adapter.test.KadaiAdapterTestUtil;
+import io.kadai.common.api.KadaiEngine;
+import io.kadai.common.test.security.WithAccessId;
+import io.kadai.task.api.TaskState;
+import io.kadai.task.api.models.Task;
+import java.time.Duration;
+import java.util.List;
+
+import org.assertj.core.api.ThrowingConsumer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Acceptance test for the minimal Camunda 8 Orchestration Cluster permissions required by the
+ * adapter.
+ *
+ * <p>Camunda Process Test 8.9.12 does not yet provide first-class OAuth2/authorization fixtures.
+ * Its managed secure runtime uses HTTP Basic authentication, so this test verifies the permission
+ * boundary with a restricted basic-auth user and seeded authorizations.
+ */
+@DirtiesContext
+@TestPropertySource(
+    properties = {
+      "camunda.process-test.multi-tenancy-enabled=true",
+      "camunda.client.worker.defaults.enabled=false"
+    })
+@KadaiAdapterCamunda8SpringBootTest
+class MinimalPermissionsAccTest {
+
+  private static final String DEFAULT_TENANT = "<default>";
+  private static final String PROCESS_ID = "Test_Process";
+  private static final String RESTRICTED_USERNAME = "kadai-adapter";
+  private static final String RESTRICTED_PASSWORD = "kadai-adapter";
+
+  @Autowired private AdapterManager adapterManager;
+  @Autowired private Camunda8System camunda8System;
+  @Autowired private Camunda8SystemConnectorConfiguration connectorConfiguration;
+  @Autowired private Camunda8TestUtil camunda8TestUtil;
+  @Autowired private CamundaClient adminClient;
+  @Autowired private CamundaProcessTestContext processTestContext;
+  @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
+  @Autowired private KadaiEngine kadaiEngine;
+  @Autowired private UserTaskCancellation userTaskCancellation;
+  @Autowired private UserTaskCompletion userTaskCompletion;
+  @Autowired private UserTaskCreation userTaskCreation;
+
+  @Test
+  @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
+  void should_RunAllAdapterFlowsSuccessfully_WhenMinimalCamunda8PermissionsAreConfigured()
+      throws Exception {
+    createKadaiMasterData();
+    createRestrictedCamundaUser();
+    grantMinimalAdapterPermissions();
+
+    try (CamundaClient restrictedClient = createRestrictedClient()) {
+      registerRestrictedOutboundConnector(restrictedClient);
+
+      Task claimAndCompleteTask = createKadaiTaskViaRestrictedCreatedListener(restrictedClient);
+      claimCamundaTaskViaRestrictedOutboundConnector(claimAndCompleteTask);
+      cancelCamundaTaskClaimViaRestrictedOutboundConnector(claimAndCompleteTask);
+      completeCamundaTaskViaRestrictedOutboundConnector(restrictedClient, claimAndCompleteTask);
+
+      Task cancelledTask = createKadaiTaskViaRestrictedCreatedListener(restrictedClient);
+      cancelProcessAndKadaiTaskViaRestrictedCancelledListener(restrictedClient, cancelledTask);
+    }
+  }
+
+  private void createKadaiMasterData() throws Exception {
+    kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+  }
+
+  private void createRestrictedCamundaUser() {
+    adminClient
+        .newCreateUserCommand()
+        .username(RESTRICTED_USERNAME)
+        .password(RESTRICTED_PASSWORD)
+        .name("KADAI Adapter")
+        .email("kadai-adapter@example.org")
+        .send()
+        .join();
+    adminClient
+        .newAssignUserToTenantCommand()
+        .username(RESTRICTED_USERNAME)
+        .tenantId(DEFAULT_TENANT)
+        .send()
+        .join();
+  }
+
+  private void grantMinimalAdapterPermissions() {
+    createAuthorization(UPDATE_PROCESS_INSTANCE);
+    createAuthorization(READ_USER_TASK, CLAIM_USER_TASK, UPDATE_USER_TASK, COMPLETE_USER_TASK);
+  }
+
+  private void createAuthorization(PermissionType... permissionTypes) {
+    adminClient
+        .newCreateAuthorizationCommand()
+        .ownerId(RESTRICTED_USERNAME)
+        .ownerType(OwnerType.USER)
+        .resourceId(PROCESS_ID)
+        .resourceType(PROCESS_DEFINITION)
+        .permissionTypes(permissionTypes)
+        .send()
+        .join();
+  }
+
+  private CamundaClient createRestrictedClient() {
+    return processTestContext.createClient(
+        builder ->
+            builder
+                .credentialsProvider(
+                    CredentialsProvider.newBasicAuthCredentialsProviderBuilder()
+                        .username(RESTRICTED_USERNAME)
+                        .password(RESTRICTED_PASSWORD)
+                        .build())
+                .defaultTenantId(DEFAULT_TENANT));
+  }
+
+  private void registerRestrictedOutboundConnector(CamundaClient restrictedClient) {
+    Camunda8SystemConnectorImpl connector =
+        new Camunda8SystemConnectorImpl(
+            camunda8System,
+            new Camunda8TaskClaimer(restrictedClient, connectorConfiguration),
+            new Camunda8TaskCompleter(restrictedClient, connectorConfiguration),
+            new Camunda8TaskClaimCanceler(restrictedClient, connectorConfiguration));
+
+    adapterManager.getOutboundSystemConnectors().put(camunda8System.getRestAddress(), connector);
+  }
+
+  private Task createKadaiTaskViaRestrictedCreatedListener(CamundaClient restrictedClient) {
+    ProcessInstanceEvent processInstance = startProcessInstance();
+    CamundaAssert.assertThat(processInstance).isActive();
+
+    camunda8TestUtil.waitUntil(
+        () ->
+            handleNextJob(
+                restrictedClient,
+                "kadai-adapter-create",
+                USER_TASK_CREATED_JOB_WORKER_TYPE,
+                userTaskCreation::receiveTaskCreatedEvent));
+
+    camunda8TestUtil.waitUntil(
+        () ->
+            getKadaiTasksByProcessInstance(processInstance).stream()
+                .anyMatch(task -> task.getState() == TaskState.READY));
+
+    Task task = getOnlyKadaiTaskByProcessInstance(processInstance);
+    assertThat(task.getState()).isEqualTo(TaskState.READY);
+    return task;
+  }
+
+  private ProcessInstanceEvent startProcessInstance() {
+    return adminClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(PROCESS_ID)
+        .latestVersion()
+        .tenantId(DEFAULT_TENANT)
+        .send()
+        .join();
+  }
+
+  private boolean handleNextJob(
+      CamundaClient workerClient,
+      String workerName,
+      String jobType,
+      ThrowingConsumer<ActivatedJob> handler) {
+    List<ActivatedJob> jobs =
+        workerClient
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(1)
+            .workerName(workerName)
+            .timeout(Duration.ofSeconds(30))
+            .tenantId(DEFAULT_TENANT)
+            .requestTimeout(Duration.ofSeconds(1))
+            .send()
+            .join()
+            .getJobs();
+
+    if (jobs.isEmpty()) {
+      return false;
+    }
+
+    ActivatedJob job = jobs.get(0);
+    try {
+      handler.accept(job);
+      workerClient.newCompleteCommand(job).send().join();
+      return true;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to handle job type '" + jobType + "'", e);
+    }
+  }
+
+  private void claimCamundaTaskViaRestrictedOutboundConnector(Task kadaiTask) throws Exception {
+    final long camundaTaskKey = extractUserTaskKeyFromTaskId(kadaiTask.getExternalId());
+
+    kadaiEngine.getTaskService().claim(kadaiTask.getId());
+
+    Task claimedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+    assertThat(claimedKadaiTask.getState()).isEqualTo(TaskState.CLAIMED);
+    assertThat(claimedKadaiTask.getOwner()).isEqualTo("admin");
+    camunda8TestUtil.waitUntil(
+        () -> "admin".equals(camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey)));
+  }
+
+  private void cancelCamundaTaskClaimViaRestrictedOutboundConnector(Task kadaiTask)
+      throws Exception {
+    long camundaTaskKey = extractUserTaskKeyFromTaskId(kadaiTask.getExternalId());
+
+    kadaiEngine.getTaskService().cancelClaim(kadaiTask.getId());
+
+    Task readyKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+    assertThat(readyKadaiTask.getState()).isEqualTo(TaskState.READY);
+    camunda8TestUtil.waitUntil(
+        () -> camunda8TestUtil.getCamundaTaskAssignee(camundaTaskKey) == null);
+  }
+
+  private void completeCamundaTaskViaRestrictedOutboundConnector(
+      CamundaClient restrictedClient, Task kadaiTask) throws Exception {
+    final long camundaTaskKey = extractUserTaskKeyFromTaskId(kadaiTask.getExternalId());
+
+    kadaiEngine.getTaskService().claim(kadaiTask.getId());
+    kadaiEngine.getTaskService().completeTask(kadaiTask.getId());
+
+    camunda8TestUtil.waitUntil(
+        () ->
+            handleNextJob(
+                restrictedClient,
+                "kadai-adapter-complete",
+                USER_TASK_COMPLETED_JOB_WORKER_TYPE,
+                userTaskCompletion::receiveTaskCompletedEvent));
+
+    Task completedKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+    assertThat(completedKadaiTask.getState()).isEqualTo(TaskState.COMPLETED);
+    camunda8TestUtil.waitUntil(
+        () -> "COMPLETED".equals(camunda8TestUtil.getCamundaTaskStatus(camundaTaskKey)));
+  }
+
+  private void cancelProcessAndKadaiTaskViaRestrictedCancelledListener(
+      CamundaClient restrictedClient, Task kadaiTask) throws Exception {
+    adminClient
+        .newCancelInstanceCommand(Long.parseLong(kadaiTask.getBusinessProcessId()))
+        .send()
+        .join();
+
+    camunda8TestUtil.waitUntil(
+        () ->
+            handleNextJob(
+                restrictedClient,
+                "kadai-adapter-cancel",
+                USER_TASK_CANCELLED_JOB_WORKER_TYPE,
+                userTaskCancellation::receiveTaskCancelledEvent));
+
+    camunda8TestUtil.waitUntil(
+        () ->
+            kadaiEngine.getTaskService().getTask(kadaiTask.getId()).getState()
+                == TaskState.CANCELLED);
+
+    Task cancelledKadaiTask = kadaiEngine.getTaskService().getTask(kadaiTask.getId());
+    assertThat(cancelledKadaiTask.getState()).isEqualTo(TaskState.CANCELLED);
+  }
+
+  private Task getOnlyKadaiTaskByProcessInstance(ProcessInstanceEvent processInstance) {
+    List<Task> tasks = getKadaiTasksByProcessInstance(processInstance);
+    assertThat(tasks).hasSize(1);
+    return tasks.get(0);
+  }
+
+  private List<Task> getKadaiTasksByProcessInstance(ProcessInstanceEvent processInstance) {
+    String processInstanceKey = String.valueOf(processInstance.getProcessInstanceKey());
+    return kadaiEngine.getTaskService().createTaskQuery().list().stream()
+        .map(taskSummary -> getKadaiTask(taskSummary.getId()))
+        .filter(task -> processInstanceKey.equals(task.getBusinessProcessId()))
+        .toList();
+  }
+
+  private Task getKadaiTask(String taskId) {
+    try {
+      return kadaiEngine.getTaskService().getTask(taskId);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load KADAI task '" + taskId + "'", e);
+    }
+  }
+}

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/MinimalPermissionsAccTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/MinimalPermissionsAccTest.java
@@ -21,15 +21,9 @@ import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.process.test.api.CamundaProcessTestContext;
 import io.camunda.process.test.api.TestDeployment;
-import io.kadai.adapter.manager.AdapterManager;
+import io.camunda.process.test.impl.proxy.CamundaClientProxy;
 import io.kadai.adapter.systemconnector.camunda.Camunda8TestUtil;
 import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
-import io.kadai.adapter.systemconnector.camunda.api.impl.Camunda8SystemConnectorImpl;
-import io.kadai.adapter.systemconnector.camunda.api.impl.Camunda8TaskClaimCanceler;
-import io.kadai.adapter.systemconnector.camunda.api.impl.Camunda8TaskClaimer;
-import io.kadai.adapter.systemconnector.camunda.api.impl.Camunda8TaskCompleter;
-import io.kadai.adapter.systemconnector.camunda.config.Camunda8System;
-import io.kadai.adapter.systemconnector.camunda.config.Camunda8SystemConnectorConfiguration;
 import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCancellation;
 import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCompletion;
 import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCreation;
@@ -66,11 +60,8 @@ class MinimalPermissionsAccTest {
   private static final String RESTRICTED_USERNAME = "kadai-adapter";
   private static final String RESTRICTED_PASSWORD = "kadai-adapter";
 
-  @Autowired private AdapterManager adapterManager;
-  @Autowired private Camunda8System camunda8System;
-  @Autowired private Camunda8SystemConnectorConfiguration connectorConfiguration;
+  @Autowired private CamundaClientProxy camundaClientProxy;
   @Autowired private Camunda8TestUtil camunda8TestUtil;
-  @Autowired private CamundaClient adminClient;
   @Autowired private CamundaProcessTestContext processTestContext;
   @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
   @Autowired private KadaiEngine kadaiEngine;
@@ -83,29 +74,34 @@ class MinimalPermissionsAccTest {
   @TestDeployment(resources = "processes/sayHello.bpmn")
   void should_RunAllAdapterFlowsSuccessfully_WhenMinimalCamunda8PermissionsAreConfigured()
       throws Exception {
-    createKadaiMasterData();
-    createRestrictedCamundaUser();
-    grantMinimalAdapterPermissions();
+    CamundaClient adminClient =
+        processTestContext.createClient(builder -> builder.defaultTenantId(DEFAULT_TENANT));
 
-    try (CamundaClient restrictedClient = createRestrictedClient()) {
-      registerRestrictedOutboundConnector(restrictedClient);
+    kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+    createRestrictedCamundaUser(adminClient);
+    grantMinimalAdapterPermissions(adminClient);
 
-      Task claimAndCompleteTask = createKadaiTaskViaRestrictedCreatedListener(restrictedClient);
+    CamundaClient restrictedClient = createRestrictedClient();
+    camundaClientProxy.setDelegate(restrictedClient);
+    try {
+      Task claimAndCompleteTask =
+          createKadaiTaskViaRestrictedCreatedListener(adminClient, restrictedClient);
+
       claimCamundaTaskViaRestrictedOutboundConnector(claimAndCompleteTask);
       cancelCamundaTaskClaimViaRestrictedOutboundConnector(claimAndCompleteTask);
       completeCamundaTaskViaRestrictedOutboundConnector(restrictedClient, claimAndCompleteTask);
 
-      Task cancelledTask = createKadaiTaskViaRestrictedCreatedListener(restrictedClient);
-      cancelProcessAndKadaiTaskViaRestrictedCancelledListener(restrictedClient, cancelledTask);
+      Task cancelledTask =
+          createKadaiTaskViaRestrictedCreatedListener(adminClient, restrictedClient);
+      cancelProcessAndKadaiTaskViaRestrictedCancelledListener(
+          adminClient, restrictedClient, cancelledTask);
+    } finally {
+      camundaClientProxy.setDelegate(adminClient);
     }
   }
 
-  private void createKadaiMasterData() throws Exception {
-    kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
-    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
-  }
-
-  private void createRestrictedCamundaUser() {
+  private void createRestrictedCamundaUser(CamundaClient adminClient) {
     adminClient
         .newCreateUserCommand()
         .username(RESTRICTED_USERNAME)
@@ -122,12 +118,13 @@ class MinimalPermissionsAccTest {
         .join();
   }
 
-  private void grantMinimalAdapterPermissions() {
-    createAuthorization(UPDATE_PROCESS_INSTANCE);
-    createAuthorization(READ_USER_TASK, CLAIM_USER_TASK, UPDATE_USER_TASK, COMPLETE_USER_TASK);
+  private void grantMinimalAdapterPermissions(CamundaClient adminClient) {
+    createAuthorization(adminClient, UPDATE_PROCESS_INSTANCE);
+    createAuthorization(
+        adminClient, READ_USER_TASK, CLAIM_USER_TASK, UPDATE_USER_TASK, COMPLETE_USER_TASK);
   }
 
-  private void createAuthorization(PermissionType... permissionTypes) {
+  private void createAuthorization(CamundaClient adminClient, PermissionType... permissionTypes) {
     adminClient
         .newCreateAuthorizationCommand()
         .ownerId(RESTRICTED_USERNAME)
@@ -151,19 +148,9 @@ class MinimalPermissionsAccTest {
                 .defaultTenantId(DEFAULT_TENANT));
   }
 
-  private void registerRestrictedOutboundConnector(CamundaClient restrictedClient) {
-    Camunda8SystemConnectorImpl connector =
-        new Camunda8SystemConnectorImpl(
-            camunda8System,
-            new Camunda8TaskClaimer(restrictedClient, connectorConfiguration),
-            new Camunda8TaskCompleter(restrictedClient, connectorConfiguration),
-            new Camunda8TaskClaimCanceler(restrictedClient, connectorConfiguration));
-
-    adapterManager.getOutboundSystemConnectors().put(camunda8System.getRestAddress(), connector);
-  }
-
-  private Task createKadaiTaskViaRestrictedCreatedListener(CamundaClient restrictedClient) {
-    ProcessInstanceEvent processInstance = startProcessInstance();
+  private Task createKadaiTaskViaRestrictedCreatedListener(
+      CamundaClient adminClient, CamundaClient restrictedClient) {
+    ProcessInstanceEvent processInstance = startProcessInstance(adminClient);
     CamundaAssert.assertThat(processInstance).isActive();
 
     camunda8TestUtil.waitUntil(
@@ -185,7 +172,7 @@ class MinimalPermissionsAccTest {
     return task;
   }
 
-  private ProcessInstanceEvent startProcessInstance() {
+  private ProcessInstanceEvent startProcessInstance(CamundaClient adminClient) {
     return adminClient
         .newCreateInstanceCommand()
         .bpmnProcessId(PROCESS_ID)
@@ -242,7 +229,7 @@ class MinimalPermissionsAccTest {
   }
 
   private void cancelProcessAndKadaiTaskViaRestrictedCancelledListener(
-      CamundaClient restrictedClient, Task kadaiTask) throws Exception {
+      CamundaClient adminClient, CamundaClient restrictedClient, Task kadaiTask) throws Exception {
     adminClient
         .newCancelInstanceCommand(Long.parseLong(kadaiTask.getBusinessProcessId()))
         .send()

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/MinimalPermissionsAccTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/MinimalPermissionsAccTest.java
@@ -6,6 +6,7 @@ import static io.camunda.client.api.search.enums.PermissionType.READ_USER_TASK;
 import static io.camunda.client.api.search.enums.PermissionType.UPDATE_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.PermissionType.UPDATE_USER_TASK;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.kadai.adapter.systemconnector.camunda.Camunda8TestUtil.handleNextJob;
 import static io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCancellation.USER_TASK_CANCELLED_JOB_WORKER_TYPE;
 import static io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCompletion.USER_TASK_COMPLETED_JOB_WORKER_TYPE;
 import static io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCreation.USER_TASK_CREATED_JOB_WORKER_TYPE;
@@ -14,7 +15,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CredentialsProvider;
-import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
@@ -38,10 +38,7 @@ import io.kadai.common.api.KadaiEngine;
 import io.kadai.common.test.security.WithAccessId;
 import io.kadai.task.api.TaskState;
 import io.kadai.task.api.models.Task;
-import java.time.Duration;
 import java.util.List;
-
-import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
@@ -174,6 +171,7 @@ class MinimalPermissionsAccTest {
             handleNextJob(
                 restrictedClient,
                 "kadai-adapter-create",
+                DEFAULT_TENANT,
                 USER_TASK_CREATED_JOB_WORKER_TYPE,
                 userTaskCreation::receiveTaskCreatedEvent));
 
@@ -195,38 +193,6 @@ class MinimalPermissionsAccTest {
         .tenantId(DEFAULT_TENANT)
         .send()
         .join();
-  }
-
-  private boolean handleNextJob(
-      CamundaClient workerClient,
-      String workerName,
-      String jobType,
-      ThrowingConsumer<ActivatedJob> handler) {
-    List<ActivatedJob> jobs =
-        workerClient
-            .newActivateJobsCommand()
-            .jobType(jobType)
-            .maxJobsToActivate(1)
-            .workerName(workerName)
-            .timeout(Duration.ofSeconds(30))
-            .tenantId(DEFAULT_TENANT)
-            .requestTimeout(Duration.ofSeconds(1))
-            .send()
-            .join()
-            .getJobs();
-
-    if (jobs.isEmpty()) {
-      return false;
-    }
-
-    ActivatedJob job = jobs.get(0);
-    try {
-      handler.accept(job);
-      workerClient.newCompleteCommand(job).send().join();
-      return true;
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to handle job type '" + jobType + "'", e);
-    }
   }
 
   private void claimCamundaTaskViaRestrictedOutboundConnector(Task kadaiTask) throws Exception {
@@ -265,6 +231,7 @@ class MinimalPermissionsAccTest {
             handleNextJob(
                 restrictedClient,
                 "kadai-adapter-complete",
+                DEFAULT_TENANT,
                 USER_TASK_COMPLETED_JOB_WORKER_TYPE,
                 userTaskCompletion::receiveTaskCompletedEvent));
 
@@ -286,6 +253,7 @@ class MinimalPermissionsAccTest {
             handleNextJob(
                 restrictedClient,
                 "kadai-adapter-cancel",
+                DEFAULT_TENANT,
                 USER_TASK_CANCELLED_JOB_WORKER_TYPE,
                 userTaskCancellation::receiveTaskCancelledEvent));
 


### PR DESCRIPTION
Ran locally by removing e.g. `UPDATE_USER_TASK` - test failed as expected.
No need for automated test on this negative view imo.

<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [ ] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: