### PR TITLE
Closes #382 - Test Camunda 8 Job-Workers with REST, gRPC & Streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Thumbs.db
 
 # java-format
 .java-format-cache
+/.ai/mcp/mcp.json

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/AbstractJobWorkerCommunicationAccTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/AbstractJobWorkerCommunicationAccTest.java
@@ -1,0 +1,142 @@
+package io.kadai.adapter.systemconnector.camunda.acceptance;
+
+import static io.kadai.adapter.systemconnector.camunda.tasklistener.util.ReferencedTaskCreator.extractUserTaskKeyFromTaskId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.spring.properties.CamundaClientProperties;
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.TestDeployment;
+import io.kadai.adapter.monitoring.MonitoredComponent;
+import io.kadai.adapter.systemconnector.camunda.Camunda8TestUtil;
+import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCancellation;
+import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCompletion;
+import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCreation;
+import io.kadai.adapter.test.KadaiAdapterTestUtil;
+import io.kadai.common.api.KadaiEngine;
+import io.kadai.common.test.security.WithAccessId;
+import io.kadai.task.api.TaskState;
+import io.kadai.task.api.models.Task;
+import io.kadai.task.api.models.TaskSummary;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+abstract class AbstractJobWorkerCommunicationAccTest {
+
+  private static final String PROCESS_ID = "Test_Process";
+
+  @Autowired private CamundaClient client;
+  @Autowired private CamundaClientProperties clientProperties;
+  @Autowired private Camunda8TestUtil camunda8TestUtil;
+  @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
+  @Autowired private KadaiEngine kadaiEngine;
+  @Autowired private UserTaskCancellation userTaskCancellation;
+  @Autowired private UserTaskCompletion userTaskCompletion;
+  @Autowired private UserTaskCreation userTaskCreation;
+
+  @Test
+  @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/sayHello.bpmn")
+  void should_RunAllProductionJobWorkersWithConfiguredCommunication() throws Exception {
+    assertThat(clientProperties.getPreferRestOverGrpc()).isEqualTo(expectedPreferRestOverGrpc());
+    assertThat(clientProperties.getWorker().getDefaults().getStreamEnabled())
+        .isEqualTo(expectedStreamEnabled());
+
+    kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+
+    Task taskToComplete = createKadaiTaskViaUserTaskCreationJobWorker();
+    completeKadaiTaskViaUserTaskCompletionJobWorker(taskToComplete);
+
+    Task taskToCancel = createKadaiTaskViaUserTaskCreationJobWorker();
+    cancelKadaiTaskViaUserTaskCancellationJobWorker(taskToCancel);
+
+    assertSuccessfulRun(userTaskCreation);
+    assertSuccessfulRun(userTaskCompletion);
+    assertSuccessfulRun(userTaskCancellation);
+  }
+
+  protected abstract boolean expectedPreferRestOverGrpc();
+
+  protected boolean expectedStreamEnabled() {
+    return false;
+  }
+
+  private Task createKadaiTaskViaUserTaskCreationJobWorker() {
+    var processInstance =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .send()
+            .join();
+
+    CamundaAssert.assertThat(processInstance).isActive();
+
+    camunda8TestUtil.waitUntil(
+        () ->
+            getKadaiTasksByProcessInstance(processInstance.getProcessInstanceKey()).stream()
+                .anyMatch(task -> task.getState() == TaskState.READY));
+
+    Task task = getOnlyKadaiTaskByProcessInstance(processInstance.getProcessInstanceKey());
+    assertThat(task.getState()).isEqualTo(TaskState.READY);
+    return task;
+  }
+
+  private void completeKadaiTaskViaUserTaskCompletionJobWorker(Task kadaiTask) {
+    long userTaskKey = extractUserTaskKeyFromTaskId(kadaiTask.getExternalId());
+
+    client.newCompleteUserTaskCommand(userTaskKey).send().join();
+
+    camunda8TestUtil.waitUntil(
+        () -> kadaiEngine.getTaskService().getTask(kadaiTask.getId()).getState()
+            == TaskState.COMPLETED);
+
+    Task completedTask = getKadaiTask(kadaiTask.getId());
+    assertThat(completedTask.getState()).isEqualTo(TaskState.COMPLETED);
+  }
+
+  private void cancelKadaiTaskViaUserTaskCancellationJobWorker(Task kadaiTask) {
+    client
+        .newCancelInstanceCommand(Long.parseLong(kadaiTask.getBusinessProcessId()))
+        .send()
+        .join();
+
+    camunda8TestUtil.waitUntil(
+        () -> kadaiEngine.getTaskService().getTask(kadaiTask.getId()).getState()
+            == TaskState.CANCELLED);
+
+    Task cancelledTask = getKadaiTask(kadaiTask.getId());
+    assertThat(cancelledTask.getState()).isEqualTo(TaskState.CANCELLED);
+  }
+
+  private Task getOnlyKadaiTaskByProcessInstance(long processInstanceKey) {
+    List<Task> tasks = getKadaiTasksByProcessInstance(processInstanceKey);
+    assertThat(tasks).hasSize(1);
+    return tasks.get(0);
+  }
+
+  private List<Task> getKadaiTasksByProcessInstance(long processInstanceKey) {
+    return kadaiEngine.getTaskService().createTaskQuery().list().stream()
+        .map(TaskSummary::getId)
+        .map(this::getKadaiTask)
+        .filter(task -> String.valueOf(processInstanceKey).equals(task.getBusinessProcessId()))
+        .toList();
+  }
+
+  private Task getKadaiTask(String taskId) {
+    try {
+      return kadaiEngine.getTaskService().getTask(taskId);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load KADAI task '" + taskId + "'", e);
+    }
+  }
+
+  private void assertSuccessfulRun(MonitoredComponent monitoredComponent) {
+    assertThat(monitoredComponent.getLastRun().getEnd()).isNotNull();
+    assertThat(monitoredComponent.getLastRun().isSuccessful()).isTrue();
+    assertThat(monitoredComponent.getExpectedRunDuration()).isGreaterThanOrEqualTo(Duration.ZERO);
+  }
+}

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/JobWorkerDefaultRestAccTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/JobWorkerDefaultRestAccTest.java
@@ -1,0 +1,14 @@
+package io.kadai.adapter.systemconnector.camunda.acceptance;
+
+import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@DirtiesContext
+@KadaiAdapterCamunda8SpringBootTest
+class JobWorkerDefaultRestAccTest extends AbstractJobWorkerCommunicationAccTest {
+
+  @Override
+  protected boolean expectedPreferRestOverGrpc() {
+    return true;
+  }
+}

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/JobWorkerGrpcAccTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/JobWorkerGrpcAccTest.java
@@ -1,0 +1,16 @@
+package io.kadai.adapter.systemconnector.camunda.acceptance;
+
+import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+@DirtiesContext
+@TestPropertySource(properties = "camunda.client.prefer-rest-over-grpc=false")
+@KadaiAdapterCamunda8SpringBootTest
+class JobWorkerGrpcAccTest extends AbstractJobWorkerCommunicationAccTest {
+
+  @Override
+  protected boolean expectedPreferRestOverGrpc() {
+    return false;
+  }
+}

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/JobWorkerRestAccTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/JobWorkerRestAccTest.java
@@ -1,0 +1,16 @@
+package io.kadai.adapter.systemconnector.camunda.acceptance;
+
+import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+@DirtiesContext
+@TestPropertySource(properties = "camunda.client.prefer-rest-over-grpc=true")
+@KadaiAdapterCamunda8SpringBootTest
+class JobWorkerRestAccTest extends AbstractJobWorkerCommunicationAccTest {
+
+  @Override
+  protected boolean expectedPreferRestOverGrpc() {
+    return true;
+  }
+}

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/JobWorkerStreamingAccTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/JobWorkerStreamingAccTest.java
@@ -1,0 +1,25 @@
+package io.kadai.adapter.systemconnector.camunda.acceptance;
+
+import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+@DirtiesContext
+@TestPropertySource(
+    properties = {
+      "camunda.client.worker.defaults.stream-enabled=true",
+      "camunda.client.worker.defaults.poll-interval=PT1M"
+    })
+@KadaiAdapterCamunda8SpringBootTest
+class JobWorkerStreamingAccTest extends AbstractJobWorkerCommunicationAccTest {
+
+  @Override
+  protected boolean expectedPreferRestOverGrpc() {
+    return true;
+  }
+
+  @Override
+  protected boolean expectedStreamEnabled() {
+    return true;
+  }
+}


### PR DESCRIPTION
<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [x] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: