### PR TITLE
Closes #398 - Global User-Task Listeners

### DIFF
--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/pom.xml
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>jar</packaging>
+  <artifactId>kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example</artifactId>
+
+  <name>${project.groupId}:${project.artifactId}</name>
+  <url>http://maven.apache.org</url>
+
+  <parent>
+    <groupId>io.kadai</groupId>
+    <artifactId>kadai-adapter-camunda8-parent</artifactId>
+    <version>11.3.3-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.kadai</groupId>
+      <artifactId>kadai-adapter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.kadai</groupId>
+      <artifactId>kadai-adapter-camunda-8-system-connector</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.kadai</groupId>
+      <artifactId>kadai-adapter-kadai-connector</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.db2</groupId>
+      <artifactId>jcc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring.boot}</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/src/main/java/io/kadai/adapter/KadaiAdapterApplicationC8GlobalUserTaskListeners.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/src/main/java/io/kadai/adapter/KadaiAdapterApplicationC8GlobalUserTaskListeners.java
@@ -63,6 +63,10 @@ public class KadaiAdapterApplicationC8GlobalUserTaskListeners {
                   "kadai-complete-task",
                   UserTaskCompletion.USER_TASK_COMPLETED_JOB_WORKER_TYPE,
                   COMPLETING),
+              // Camunda 8.9 currently has a known defect:
+              // https://github.com/camunda/camunda/issues/51630
+              // Global canceling listeners are not triggered unless a model-level canceling
+              // listener also exists (which unfortunately attempts to cancel twice).
               new GlobalUserTaskListenerDefinition(
                   "kadai-cancel-task",
                   UserTaskCancellation.USER_TASK_CANCELLED_JOB_WORKER_TYPE,

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/src/main/java/io/kadai/adapter/KadaiAdapterApplicationC8GlobalUserTaskListeners.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/src/main/java/io/kadai/adapter/KadaiAdapterApplicationC8GlobalUserTaskListeners.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright [2024] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package io.kadai.adapter;
+
+import static io.camunda.client.api.search.enums.GlobalTaskListenerEventType.CANCELING;
+import static io.camunda.client.api.search.enums.GlobalTaskListenerEventType.COMPLETING;
+import static io.camunda.client.api.search.enums.GlobalTaskListenerEventType.CREATING;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCancellation;
+import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCompletion;
+import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCreation;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/** Application that provides an adapter between KADAI and one or more external systems. */
+@SpringBootApplication
+@EnableScheduling
+@EnableTransactionManagement
+public class KadaiAdapterApplicationC8GlobalUserTaskListeners {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(KadaiAdapterApplicationC8GlobalUserTaskListeners.class);
+
+  public static void main(String[] args) {
+    SpringApplication.run(KadaiAdapterApplicationC8GlobalUserTaskListeners.class, args);
+  }
+
+  @Bean
+  ApplicationRunner configureGlobalUserTaskListeners(CamundaClient client) {
+    return args -> {
+      List<GlobalUserTaskListenerDefinition> globalListeners =
+          List.of(
+              new GlobalUserTaskListenerDefinition(
+                  "kadai-create-task",
+                  UserTaskCreation.USER_TASK_CREATED_JOB_WORKER_TYPE,
+                  CREATING),
+              new GlobalUserTaskListenerDefinition(
+                  "kadai-complete-task",
+                  UserTaskCompletion.USER_TASK_COMPLETED_JOB_WORKER_TYPE,
+                  COMPLETING),
+              new GlobalUserTaskListenerDefinition(
+                  "kadai-cancel-task",
+                  UserTaskCancellation.USER_TASK_CANCELLED_JOB_WORKER_TYPE,
+                  CANCELING));
+
+      globalListeners.forEach(listener -> configureGlobalUserTaskListener(client, listener));
+    };
+  }
+
+  private void configureGlobalUserTaskListener(
+      CamundaClient client, GlobalUserTaskListenerDefinition listener) {
+    deleteGlobalUserTaskListenerIfPresent(client, listener.id());
+
+    client
+        .newCreateGlobalTaskListenerRequest()
+        .id(listener.id())
+        .type(listener.type())
+        .eventTypes(listener.eventType())
+        .priority(50)
+        .send()
+        .join();
+
+    LOGGER.info(
+        "Configured Camunda global user task listener '{}' for event '{}' with type '{}'",
+        listener.id(),
+        listener.eventType(),
+        listener.type());
+  }
+
+  private void deleteGlobalUserTaskListenerIfPresent(CamundaClient client, String id) {
+    try {
+      client.newDeleteGlobalTaskListenerRequest(id).send().join();
+    } catch (RuntimeException e) {
+      LOGGER.debug("Global user task listener '{}' did not exist before startup", id, e);
+    }
+  }
+
+  private record GlobalUserTaskListenerDefinition(
+      String id, String type, GlobalTaskListenerEventType eventType) {}
+}

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/src/main/java/io/kadai/taskrouting/ExampleTaskRouter.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/src/main/java/io/kadai/taskrouting/ExampleTaskRouter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright [2024] [envite consulting GmbH]
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *
+ */
+
+package io.kadai.taskrouting;
+
+import io.kadai.common.api.KadaiEngine;
+import io.kadai.spi.routing.api.TaskRoutingProvider;
+import io.kadai.task.api.models.Task;
+
+/** This is a sample implementation of TaskRouter. */
+public class ExampleTaskRouter implements TaskRoutingProvider {
+
+  @Override
+  public void initialize(KadaiEngine kadaiEngine) {
+    // no-op
+  }
+
+  @Override
+  public String determineWorkbasketId(Task task) {
+    return "WBI:100000000000000000000000000000000001";
+  }
+}

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/src/main/resources/application.properties
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/src/main/resources/application.properties
@@ -1,0 +1,42 @@
+# Spring
+server.port=18083
+spring.main.allow-bean-definition-overriding=true
+# Logging
+logging.level.io.kadai=WARN
+#logging.level.org.apache.ibatis=DEBUG
+#logging.level.org.springframework=DEBUG
+# Kernel
+kadai-adapter.kernel.run-as-user=taskadmin
+kadai-adapter.kernel.kadai-connector.batch-size=1
+kadai-adapter.kernel.scheduler.start-kadai-tasks-interval=10000
+kadai-adapter.kernel.scheduler.complete-referenced-tasks-interval=10000
+kadai-adapter.kernel.scheduler.claim-referenced-tasks-interval=10000
+kadai-adapter.kernel.scheduler.cancel-claim-referenced-tasks-interval=10000
+kadai-adapter.kernel.scheduler.check-finished-referenced-tasks-interval=10000
+kadai-adapter.kernel.kadai-connector.task-mapping.object-reference.company=DEFAULT_COMPANY
+kadai-adapter.kernel.kadai-connector.task-mapping.object-reference.system=DEFAULT_SYSTEM
+kadai-adapter.kernel.kadai-connector.task-mapping.object-reference.system-instance=DEFAULT_SYSTEM_INSTANCE
+kadai-adapter.kernel.kadai-connector.task-mapping.object-reference.type=DEFAULT_TYPE
+kadai-adapter.kernel.kadai-connector.task-mapping.object-reference.value=DEFAULT_VALUE
+#kadai.datasource.jdbcUrl = jdbc:h2:tcp://localhost:9095/mem:kadai;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;
+#kadai.datasource.jdbcUrl=jdbc:h2:mem:kadai;NON_KEYWORDS=KEY,VALUE;IGNORECASE=TRUE;LOCK_MODE=0;DB_CLOSE_ON_EXIT=FALSE
+#kadai.datasource.driverClassName=org.h2.Driver
+#kadai.datasource.username=sa
+#kadai.datasource.password=sa
+#kadai.schemaName=KADAI
+#kadai.datasource.jdbcUrl=jdbc:db2://localhost:50050/kadai
+#kadai.datasource.driverClassName=com.ibm.db2.jcc.DB2Driver
+#kadai.datasource.username=db2user
+#kadai.datasource.password=Db2password
+kadai.datasource.jdbcUrl=jdbc:postgresql://localhost:5102/postgres
+kadai.datasource.driverClassName=org.postgresql.Driver
+kadai.datasource.username=postgres
+kadai.datasource.password=postgres
+kadai.schemaName=kadai
+# Health
+management.endpoints.web.exposure.include=*
+management.endpoint.health.show-details=always
+# Camunda 8 Plugin
+camunda.client.enabled=true
+camunda.client.mode=self-managed
+camunda.client.rest-address=http://localhost:8081

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/src/main/resources/kadai.properties
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/src/main/resources/kadai.properties
@@ -1,0 +1,10 @@
+kadai.roles.user=group1 | group2|teamlead-1 |teamlead-2 |user-1-1| user-1-1| user-1-2| user-2-1| user-2-2| max|elena|simone
+kadai.roles.Admin=name=konrad,Organisation=envite|admin
+kadai.roles.business_admin=max|Moritz|businessadmin
+kadai.roles.task_admin=peter | taskadmin
+kadai.roles.monitor=john|teamlead_2 | monitor
+kadai.domains=DOMAIN_A|DOMAIN_B|DOMAIN_C
+kadai.classification.types=TASK|DOCUMENT
+kadai.classification.categories.task=EXTERNAL| manual| autoMAtic| Process
+kadai.classification.categories.document=EXTERNAL
+kadai.jobs.enabled=false

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/src/main/resources/processes/globalUserTaskListenersProcess.bpmn
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example/src/main/resources/processes/globalUserTaskListenersProcess.bpmn
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_GlobalUserTaskListeners" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:message id="Message_CancelReview" name="cancel-review">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:process id="Global_User_Task_Listeners_Process" name="Global User Task Listeners Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_GlobalListenerExample">
+      <bpmn:outgoing>Flow_Start_To_UserTask</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_Start_To_UserTask" sourceRef="StartEvent_GlobalListenerExample" targetRef="ReviewRequest" />
+    <bpmn:userTask id="ReviewRequest" name="Review request">
+      <bpmn:documentation>This task is picked up by KADAI through Camunda 8.9 global user task listeners configured on the cluster.</bpmn:documentation>
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:taskSchedule followUpDate="=date and time(&#34;2026-12-02T12:00:00Z&#34;)" />
+        <zeebe:priorityDefinition priority="=20" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=&#34;GPK_KSC&#34;" target="kadai_workbasket_key" />
+          <zeebe:input source="=&#34;L11010&#34;" target="kadai_classification_key" />
+          <zeebe:input source="=&#34;DOMAIN_A&#34;" target="kadai_domain" />
+          <zeebe:input source="=&#34;customerId,requestId&#34;" target="kadai_attributes" />
+          <zeebe:input source="=&#34;customer-4711&#34;" target="customerId" />
+          <zeebe:input source="=&#34;request-0815&#34;" target="requestId" />
+          <zeebe:input source="=&#34;Review request&#34;" target="kadai_name" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_Start_To_UserTask</bpmn:incoming>
+      <bpmn:outgoing>Flow_UserTask_To_End</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_UserTask_To_End" sourceRef="ReviewRequest" targetRef="EndEvent_GlobalListenerExample" />
+    <bpmn:sequenceFlow id="Flow_Cancel_To_End" sourceRef="CancelReviewBoundary" targetRef="EndEvent_Cancelled" />
+    <bpmn:endEvent id="EndEvent_GlobalListenerExample">
+      <bpmn:incoming>Flow_UserTask_To_End</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_Cancelled">
+      <bpmn:incoming>Flow_Cancel_To_End</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="CancelReviewBoundary" attachedToRef="ReviewRequest" cancelActivity="true">
+      <bpmn:outgoing>Flow_Cancel_To_End</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_CancelReview" messageRef="Message_CancelReview" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_GlobalUserTaskListeners">
+    <bpmndi:BPMNPlane id="BPMNPlane_GlobalUserTaskListeners" bpmnElement="Global_User_Task_Listeners_Process">
+      <bpmndi:BPMNShape id="StartEvent_GlobalListenerExample_di" bpmnElement="StartEvent_GlobalListenerExample">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ReviewRequest_di" bpmnElement="ReviewRequest">
+        <dc:Bounds x="270" y="80" width="120" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_GlobalListenerExample_di" bpmnElement="EndEvent_GlobalListenerExample">
+        <dc:Bounds x="452" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Cancelled_di" bpmnElement="EndEvent_Cancelled">
+        <dc:Bounds x="452" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CancelReviewBoundary_di" bpmnElement="CancelReviewBoundary">
+        <dc:Bounds x="312" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_Start_To_UserTask_di" bpmnElement="Flow_Start_To_UserTask">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_UserTask_To_End_di" bpmnElement="Flow_UserTask_To_End">
+        <di:waypoint x="390" y="120" />
+        <di:waypoint x="452" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Cancel_To_End_di" bpmnElement="Flow_Cancel_To_End">
+        <di:waypoint x="330" y="178" />
+        <di:waypoint x="330" y="260" />
+        <di:waypoint x="452" y="260" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/GlobalUserTaskListenerAccTest.java
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/java/io/kadai/adapter/systemconnector/camunda/acceptance/GlobalUserTaskListenerAccTest.java
@@ -1,0 +1,209 @@
+package io.kadai.adapter.systemconnector.camunda.acceptance;
+
+import static io.camunda.client.api.search.enums.GlobalTaskListenerEventType.CANCELING;
+import static io.camunda.client.api.search.enums.GlobalTaskListenerEventType.COMPLETING;
+import static io.camunda.client.api.search.enums.GlobalTaskListenerEventType.CREATING;
+import static io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCancellation.USER_TASK_CANCELLED_JOB_WORKER_TYPE;
+import static io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCompletion.USER_TASK_COMPLETED_JOB_WORKER_TYPE;
+import static io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCreation.USER_TASK_CREATED_JOB_WORKER_TYPE;
+import static io.kadai.adapter.systemconnector.camunda.tasklistener.util.ReferencedTaskCreator.extractUserTaskKeyFromTaskId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.enums.GlobalTaskListenerEventType;
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.TestDeployment;
+import io.kadai.adapter.monitoring.MonitoredComponent;
+import io.kadai.adapter.systemconnector.camunda.Camunda8TestUtil;
+import io.kadai.adapter.systemconnector.camunda.KadaiAdapterCamunda8SpringBootTest;
+import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCancellation;
+import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCompletion;
+import io.kadai.adapter.systemconnector.camunda.tasklistener.UserTaskCreation;
+import io.kadai.adapter.test.KadaiAdapterTestUtil;
+import io.kadai.common.api.KadaiEngine;
+import io.kadai.common.test.security.WithAccessId;
+import io.kadai.task.api.TaskState;
+import io.kadai.task.api.models.Task;
+import io.kadai.task.api.models.TaskSummary;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+@DirtiesContext
+@KadaiAdapterCamunda8SpringBootTest
+class GlobalUserTaskListenerAccTest {
+
+  private static final String PROCESS_ID = "Global_User_Task_Listeners_Process";
+  private static final String CREATE_LISTENER_ID = "kadai-test-global-create-task";
+  private static final String COMPLETE_LISTENER_ID = "kadai-test-global-complete-task";
+  private static final String CANCEL_LISTENER_ID = "kadai-test-global-cancel-task";
+
+  @Autowired private CamundaClient client;
+  @Autowired private Camunda8TestUtil camunda8TestUtil;
+  @Autowired private KadaiAdapterTestUtil kadaiAdapterTestUtil;
+  @Autowired private KadaiEngine kadaiEngine;
+  @Autowired private UserTaskCancellation userTaskCancellation;
+  @Autowired private UserTaskCompletion userTaskCompletion;
+  @Autowired private UserTaskCreation userTaskCreation;
+
+  @BeforeEach
+  void createGlobalUserTaskListeners() {
+    deleteGlobalUserTaskListeners();
+
+    createGlobalUserTaskListener(CREATE_LISTENER_ID, USER_TASK_CREATED_JOB_WORKER_TYPE, CREATING);
+    createGlobalUserTaskListener(
+        COMPLETE_LISTENER_ID, USER_TASK_COMPLETED_JOB_WORKER_TYPE, COMPLETING);
+    createGlobalUserTaskListener(
+        CANCEL_LISTENER_ID, USER_TASK_CANCELLED_JOB_WORKER_TYPE, CANCELING);
+  }
+
+  @AfterEach
+  void deleteGlobalUserTaskListeners() {
+    deleteGlobalUserTaskListener(CREATE_LISTENER_ID);
+    deleteGlobalUserTaskListener(COMPLETE_LISTENER_ID);
+    deleteGlobalUserTaskListener(CANCEL_LISTENER_ID);
+  }
+
+  @Test
+  @SuppressWarnings("unused")
+  @WithAccessId(user = "admin")
+  @TestDeployment(resources = "processes/globalUserTaskListenersProcess.bpmn")
+  void should_CreateCompleteAndCancelKadaiTask_When_ListenersAreConfiguredGlobally()
+      throws Exception {
+    kadaiAdapterTestUtil.createWorkbasket("GPK_KSC", "DOMAIN_A");
+    kadaiAdapterTestUtil.createClassification("L11010", "DOMAIN_A");
+
+    Task taskToComplete = createKadaiTaskViaGlobalUserTaskCreationListener(randomCorrelationKey());
+    completeKadaiTaskViaGlobalUserTaskCompletionListener(taskToComplete);
+
+    String cancellationCorrelationKey = randomCorrelationKey();
+    Task taskToCancel =
+        createKadaiTaskViaGlobalUserTaskCreationListener(cancellationCorrelationKey);
+
+    // cancelKadaiTaskViaGlobalUserTaskCancellationListener(taskToCancel,
+    // cancellationCorrelationKey);
+
+    assertSuccessfulRun(userTaskCreation);
+    assertSuccessfulRun(userTaskCompletion);
+    // Camunda 8.9 currently has a known defect:
+    // https://github.com/camunda/camunda/issues/51630
+    // Global canceling listeners are not triggered unless a model-level canceling listener also
+    // exists (which unfortunately attempts to cancel twice).
+    // assertSuccessfulRun(userTaskCancellation);
+  }
+
+  private void createGlobalUserTaskListener(
+      String id, String jobType, GlobalTaskListenerEventType eventType) {
+    client
+        .newCreateGlobalTaskListenerRequest()
+        .id(id)
+        .type(jobType)
+        .eventTypes(eventType)
+        .priority(50)
+        .send()
+        .join();
+  }
+
+  private void deleteGlobalUserTaskListener(String id) {
+    try {
+      client.newDeleteGlobalTaskListenerRequest(id).send().join();
+    } catch (RuntimeException ignored) {
+      // Listener cleanup is best-effort. The listener may not exist before the test creates it.
+    }
+  }
+
+  private Task createKadaiTaskViaGlobalUserTaskCreationListener(String correlationKey) {
+    ProcessInstanceEvent processInstance =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .variable("correlationKey", correlationKey)
+            .send()
+            .join();
+
+    CamundaAssert.assertThat(processInstance).isActive();
+
+    camunda8TestUtil.waitUntil(
+        () ->
+            getKadaiTasksByProcessInstance(processInstance.getProcessInstanceKey()).stream()
+                .anyMatch(task -> task.getState() == TaskState.READY));
+
+    Task task = getOnlyKadaiTaskByProcessInstance(processInstance.getProcessInstanceKey());
+    assertThat(task.getState()).isEqualTo(TaskState.READY);
+    assertThat(task.getDomain()).isEqualTo("DOMAIN_A");
+    assertThat(task.getName()).isEqualTo("Review request");
+    return task;
+  }
+
+  private void completeKadaiTaskViaGlobalUserTaskCompletionListener(Task kadaiTask) {
+    long userTaskKey = extractUserTaskKeyFromTaskId(kadaiTask.getExternalId());
+
+    client.newCompleteUserTaskCommand(userTaskKey).send().join();
+
+    camunda8TestUtil.waitUntil(
+        () ->
+            kadaiEngine.getTaskService().getTask(kadaiTask.getId()).getState()
+                == TaskState.COMPLETED);
+
+    Task completedTask = getKadaiTask(kadaiTask.getId());
+    assertThat(completedTask.getState()).isEqualTo(TaskState.COMPLETED);
+  }
+
+  @SuppressWarnings("unused")
+  private void cancelKadaiTaskViaGlobalUserTaskCancellationListener(
+      Task kadaiTask, String correlationKey) {
+    client
+        .newPublishMessageCommand()
+        .messageName("cancel-review")
+        .correlationKey(correlationKey)
+        .timeToLive(Duration.ofMinutes(1))
+        .send()
+        .join();
+
+    // camunda8TestUtil.waitUntil(
+    //    () -> kadaiEngine.getTaskService().getTask(kadaiTask.getId()).getState()
+    //        == TaskState.CANCELLED);
+
+    // Task cancelledTask = getKadaiTask(kadaiTask.getId());
+    // assertThat(cancelledTask.getState()).isEqualTo(TaskState.CANCELLED);
+  }
+
+  private String randomCorrelationKey() {
+    return UUID.randomUUID().toString();
+  }
+
+  private Task getOnlyKadaiTaskByProcessInstance(long processInstanceKey) {
+    List<Task> tasks = getKadaiTasksByProcessInstance(processInstanceKey);
+    assertThat(tasks).hasSize(1);
+    return tasks.get(0);
+  }
+
+  private List<Task> getKadaiTasksByProcessInstance(long processInstanceKey) {
+    return kadaiEngine.getTaskService().createTaskQuery().list().stream()
+        .map(TaskSummary::getId)
+        .map(this::getKadaiTask)
+        .filter(task -> String.valueOf(processInstanceKey).equals(task.getBusinessProcessId()))
+        .toList();
+  }
+
+  private Task getKadaiTask(String taskId) {
+    try {
+      return kadaiEngine.getTaskService().getTask(taskId);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load KADAI task '" + taskId + "'", e);
+    }
+  }
+
+  private void assertSuccessfulRun(MonitoredComponent monitoredComponent) {
+    assertThat(monitoredComponent.getLastRun().getEnd()).isNotNull();
+    assertThat(monitoredComponent.getLastRun().isSuccessful()).isTrue();
+    assertThat(monitoredComponent.getExpectedRunDuration()).isGreaterThanOrEqualTo(Duration.ZERO);
+  }
+}

--- a/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/processes/globalUserTaskListenersProcess.bpmn
+++ b/kadai-adapter-camunda8-parent/kadai-adapter-camunda-8-system-connector/src/test/resources/processes/globalUserTaskListenersProcess.bpmn
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_GlobalUserTaskListenersTest" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.9.0">
+  <bpmn:message id="Message_CancelReview" name="cancel-review">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:process id="Global_User_Task_Listeners_Process" name="Global User Task Listeners Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_GlobalListenerExample">
+      <bpmn:outgoing>Flow_Start_To_UserTask</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_Start_To_UserTask" sourceRef="StartEvent_GlobalListenerExample" targetRef="ReviewRequest" />
+    <bpmn:userTask id="ReviewRequest" name="Review request">
+      <bpmn:documentation>This task is picked up by KADAI through Camunda 8.9 global user task listeners configured on the cluster.</bpmn:documentation>
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:taskSchedule followUpDate="=date and time(&#34;2026-12-02T12:00:00Z&#34;)" />
+        <zeebe:priorityDefinition priority="=20" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=&#34;GPK_KSC&#34;" target="kadai_workbasket_key" />
+          <zeebe:input source="=&#34;L11010&#34;" target="kadai_classification_key" />
+          <zeebe:input source="=&#34;DOMAIN_A&#34;" target="kadai_domain" />
+          <zeebe:input source="=&#34;customerId,requestId&#34;" target="kadai_attributes" />
+          <zeebe:input source="=&#34;customer-4711&#34;" target="customerId" />
+          <zeebe:input source="=&#34;request-0815&#34;" target="requestId" />
+          <zeebe:input source="=&#34;Review request&#34;" target="kadai_name" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_Start_To_UserTask</bpmn:incoming>
+      <bpmn:outgoing>Flow_UserTask_To_End</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_UserTask_To_End" sourceRef="ReviewRequest" targetRef="EndEvent_GlobalListenerExample" />
+    <bpmn:sequenceFlow id="Flow_Cancel_To_End" sourceRef="CancelReviewBoundary" targetRef="EndEvent_Cancelled" />
+    <bpmn:endEvent id="EndEvent_GlobalListenerExample">
+      <bpmn:incoming>Flow_UserTask_To_End</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_Cancelled">
+      <bpmn:incoming>Flow_Cancel_To_End</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="CancelReviewBoundary" attachedToRef="ReviewRequest" cancelActivity="true">
+      <bpmn:outgoing>Flow_Cancel_To_End</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_CancelReview" messageRef="Message_CancelReview" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_GlobalUserTaskListeners">
+    <bpmndi:BPMNPlane id="BPMNPlane_GlobalUserTaskListeners" bpmnElement="Global_User_Task_Listeners_Process">
+      <bpmndi:BPMNShape id="StartEvent_GlobalListenerExample_di" bpmnElement="StartEvent_GlobalListenerExample">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ReviewRequest_di" bpmnElement="ReviewRequest">
+        <dc:Bounds x="270" y="80" width="120" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_GlobalListenerExample_di" bpmnElement="EndEvent_GlobalListenerExample">
+        <dc:Bounds x="452" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Cancelled_di" bpmnElement="EndEvent_Cancelled">
+        <dc:Bounds x="452" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CancelReviewBoundary_di" bpmnElement="CancelReviewBoundary">
+        <dc:Bounds x="312" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_Start_To_UserTask_di" bpmnElement="Flow_Start_To_UserTask">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_UserTask_To_End_di" bpmnElement="Flow_UserTask_To_End">
+        <di:waypoint x="390" y="120" />
+        <di:waypoint x="452" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_Cancel_To_End_di" bpmnElement="Flow_Cancel_To_End">
+        <di:waypoint x="330" y="178" />
+        <di:waypoint x="330" y="260" />
+        <di:waypoint x="452" y="260" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/kadai-adapter-camunda8-parent/pom.xml
+++ b/kadai-adapter-camunda8-parent/pom.xml
@@ -26,6 +26,7 @@
   <modules>
     <module>kadai-adapter-camunda-8-system-connector</module>
     <module>kadai-adapter-camunda-8-spring-boot-example</module>
+    <module>kadai-adapter-camunda-8-spring-boot-global-user-task-listener-example</module>
     <module>kadai-adapter-camunda-8-spring-boot-multi-tenancy-example</module>
   </modules>
 </project>


### PR DESCRIPTION
Global User-Task Listeners work out-of-the-box as expected.
Unfortuantely **Delete** does **not** work.
This is a known Camunda-problem. See https://github.com/camunda/camunda/issues/51630.

Code includes commented-out Delete-Parts.
I'd still integrate this as #489 is up until Camunda fixes the bug.

<!-- if needed please write above the given line -->

## Definition of Done

- [x] The corresponding ticket is in state `In Review`
- [x] The corresponding ticket is attached to this Pull-Request
- [x] The commit-message-format `Closes #ISSUE_ID - PROBLEM/SOLUTION`
    - is present as single-commit already or
    - will be squashed on merge
- [ ] The changes pass the SonarQubeCloud-Quality-Gate
- [x] If the documentation needs an update, following there's a link to it:
- [x] If extra release-notes are required, they're listed indented below: